### PR TITLE
Documentation improvements - Metaprogramming guide

### DIFF
--- a/METAPROGRAMMING.md
+++ b/METAPROGRAMMING.md
@@ -96,7 +96,7 @@ function observed({kind, key, placement, descriptor, initializer}, get, set) {
 <a id="bound-decorator-notes"></a>
 ## Notes about the `@bound` decorator
 
-You may have seen the following pattern for creating bound methods and be wondering why a decorator would be preferred for this:
+You may have seen the following pattern for creating bound methods and be wondering why a `@bound` decorator would be preferred over this:
 
 ```js
 class Counter extends HTMLElement {

--- a/METAPROGRAMMING.md
+++ b/METAPROGRAMMING.md
@@ -6,7 +6,58 @@ Previously, metaprogramming within JavaScript was driven by use of dynamic opera
 * Decorators can manipulate private fields and private methods, whereas operations on objects are unable to manipulate the definitions of private names.
 * Decorators do their manipulations at the time the class is defined, rather than when instances are being created and used, so they may lead to patterns which are more amenable to efficient implementation.
 
-Dcorators can be used either to decorate a whole class or an individual class element (field or method). Decorators are implemented as functions which take a JSON-like representation of class element(s) as an argument and return a possibly-modified form of that, optionally with additional class elements.
+Dcorators can be used either to decorate a whole class or an individual class element (field or method).
+
+## Basic Usage
+
+Decorators are implemented as functions which take a JSON-like representation of class element(s) as an argument and return a possibly-modified form of that, optionally with additional class elements.
+
+For example, suppose we want a simple decorator to change the placement of a property so that it will be created on the prototype rather than the instance:
+
+```js
+class Demo {
+  @prototypeProp
+  x = 1
+}
+```
+
+The public field `x` above would be represented as the following class element descriptor, which will be passed into our decorator function:
+
+```js
+{
+  kind: "field"
+  key: "x",
+  placement: "own",
+  // property descriptor for Object.defineProperty
+  descriptor: { configurable: false, enumerable: true, writable: true },
+  initializer: () => 1
+}
+```
+
+To implement our decorator function, we need to take the class element descriptor and change its `placement` property to `'prototype'`:
+
+```js
+function prototypeProp(elementDescriptor) {
+  assert(kind == "field" || kind == "method");
+  // Note: this decorator would generally be used for fields, not methods, because the
+  // 'prototype' placement is already the default for non-static methods. So it would only
+  // be useful for methods if you wanted to override the default placement or the placement
+  // from a previous decorator.
+  return {
+    ...elementDescriptor,
+    placement: 'prototype'
+  }
+}
+```
+
+Thanks to the `prototypeProp` decorator, `x` will now be placed on the prototype as if we had written the following code:
+
+```js
+class Demo {}
+Demo.prototype.x = 1
+```
+
+## API
 
 The signatures of the different kinds of decorator functions are as follows:
 

--- a/METAPROGRAMMING.md
+++ b/METAPROGRAMMING.md
@@ -1,11 +1,12 @@
 # Metaprogramming with decorators
 
 Previously, metaprogramming within JavaScript was driven by use of dynamic operations that manipulate JavaScript objects, such as `Object.defineProperty`. ESnext upgrades classes with decorators, with the advantages:
-- Decorators make it more clear what's going on--users write class literals and explicitly annotate the piece of source code that is being manipulated, rather than spooky action-at-a-distance where a big object is passed into a special application-dependent class framework.
-- Decorators can manipulate private fields and private methods, whereas operations on objects are unable to manipulate the definitions of private names.
-- Decorators do their manipulations at the time the class is defined, rather than when instances are being created and used, so they may lead to patterns which are more amenable to efficient implementation.
 
-Decorators are implemented as functions which take a JSON-like representation of a class element as an argument and return a possibly-modified form of that, optionally with additional class elements. Class elements are represented in the form: 
+* Decorators make it more clear what's going on--users write class literals and explicitly annotate the piece of source code that is being manipulated, rather than spooky action-at-a-distance where a big object is passed into a special application-dependent class framework.
+* Decorators can manipulate private fields and private methods, whereas operations on objects are unable to manipulate the definitions of private names.
+* Decorators do their manipulations at the time the class is defined, rather than when instances are being created and used, so they may lead to patterns which are more amenable to efficient implementation.
+
+As stated in the readme, decorators can be used either to decorate a whole class or an individual class element (field or method). Decorators are implemented as functions which take a JSON-like representation of a class element as an argument and return a possibly-modified form of that, optionally with additional class elements. For both kinds of decorator functions, class elements are represented in the form:
 
 ```js
 {
@@ -13,26 +14,21 @@ Decorators are implemented as functions which take a JSON-like representation of
   key: String, Symbol or Private Name,
   placement: "static", "prototype" or "own",
   descriptor: Property Descriptor (argument to Object.defineProperty),
+  initializer: method used to set the initial state of the class element
 }
 ```
 
-The return value is allowed to add an `extras` property with additional class elements, and a `finisher` property, which is a callback that is called with the constructor, once it's created.
+For class element decorators, the return value is allowed to add the following additional properties:
+
+* `extras`: A property with additional class elements
+* `finisher`: A callback that is called with the constructor, once it's created.
+
+Class decorators (i.e. decorators that decorate the class as a whole) are passed in an Array of all class elements and output an object with fields `elements` for the new class elements, `constructor` for the function which should act as the construtor, and `finisher` for a similar callback.
 
 For private fields, methods or accessors, the `key` will be a Private Name--this is similar to a String or Symbol, except that it is invalid to use with property access `[]` or with operations such as `Object.defineProperty`. Instead, it can only be used with decorators.
 
-Class decorators are passed an object of this form:
-
-```js
-{
-  kind: "class"
-  elements: Array of element descriptors
-}
-```
-
-The return value has the same form plus a `finisher` property, which is a callback that is called with the constructor, once it's created.
-
-
 For example, the three decorators from README.md could be defined as follows:
+
 ```js
 // Define the class as a custom element with the given tag name
 function defineElement(tagName) {
@@ -40,8 +36,8 @@ function defineElement(tagName) {
   // in the outer function and returns a different function that's called
   // when actually decorating the class (manual currying).
   return function(classDescriptor) {
-    let {kind, elements} = classDescriptor;
-    assert(kind == "class");
+    let { kind, elements } = classDescriptor;
+    assert(kind == 'class');
     return {
       kind,
       elements,
@@ -49,19 +45,21 @@ function defineElement(tagName) {
       finisher(klass) {
         window.customElements.define(tagName, klass);
       }
-    }
-  }
+    };
+  };
 }
 
 // Replace a method with a field with a bound version of the method
 function bound(elementDescriptor) {
-  let {kind, key, placement, descriptor} = elementDescriptor;
-  assert(kind === "method");
-  if (placement == "prototype") placement = "own";
-  const {value} = descriptor;
-  function initializer() { return value.bind(this); }
+  let { kind, key, placement, descriptor } = elementDescriptor;
+  assert(kind === 'method');
+  if (placement == 'prototype') placement = 'own';
+  const { value } = descriptor;
+  function initializer() {
+    return value.bind(this);
+  }
   delete descriptor.value;
-  return { kind: "field", key, placement, descriptor, initializer };
+  return { kind: 'field', key, placement, descriptor, initializer };
 }
 
 // Whenever a read or write is done to a field, call the render()
@@ -75,7 +73,7 @@ function observed({kind, key, placement, descriptor, initializer}, get, set) {
   let underlyingDescriptor = { enumerable: false, configurable: false, writable: true };
   let underlying = { kind, key: storage, placement, descriptor: underlyingDescriptor, initializer };
   return {
-    kind: "method",
+    kind: 'method',
     key,
     placement,
     descriptor: {
@@ -86,10 +84,52 @@ function observed({kind, key, placement, descriptor, initializer}, get, set) {
         window.requestAnimationFrame(this.render);
       },
       enumerable: descriptor.enumerable,
-      configurable: descriptor.configurable,
+      configurable: descriptor.configurable
     },
     extras: [underlying]
   };
-  
+}
+```
+
+And here is an example that uses the `finisher` property for a class element:
+
+```js
+class User {
+  @readonly id;
+  email;
+
+  constructor(id = null, email = null) {
+    this.id = id;
+    this.email = email;
+  }
+}
+
+function readonly(elementDecriptor) {
+  // we don't want to set `writable` to false until after the property has been initialized
+  elementDecriptor.finisher = () => {
+    elementDecriptor.descriptor.writable = false;
+  };
+  return elementDecriptor;
+}
+```
+
+The above code is functionally equivalent to the following:
+
+```js
+class User {
+  id;
+  email;
+
+  constructor(id = null, email = null) {
+    this.id = id;
+    this.email = email;
+    // finisher
+    Object.defineProperty(this, 'id', {
+      writable: false,
+      // configurable: false and enumerable: true are the default for public class fields
+      configurable: false,
+      enumerable: true
+    });
+  }
 }
 ```

--- a/METAPROGRAMMING.md
+++ b/METAPROGRAMMING.md
@@ -147,14 +147,7 @@ You may have seen the following pattern for creating bound methods and be wonder
 class Counter extends HTMLElement {
   @observed #x = 0;
 
-  constructor() {
-    super();
-    this.onclick = this.clicked;
-  }
-
-  // made public instead of private for simplicity, but the same principles regarding
-  // arrow functions apply to both
-  clicked = () => {
+  onclick = () => {
     this.#x++;
   }
 
@@ -174,15 +167,14 @@ class Counter extends HTMLElement {
 
   constructor() {
     super();
-    this.clicked = () => this.#x++;
-    this.onclick = this.clicked;
+    this.onclick = () => this.#x++;
   }
 
   ...
 }
 ```
 
-Therefore, the `clicked` method no longer exists on the `Counter`'s prototype. Suppose our `Counter` class had a couple other regular methods in addition to `clicked`:
+Therefore, the `onclick` method no longer exists on the `Counter`'s prototype. Suppose our `Counter` class had a couple other regular methods in addition to `onclick`:
 
 ```js
 class Counter extends HTMLElement {
@@ -200,52 +192,123 @@ Counter.prototype.foo  // defined
 Counter.prototype.bar  // defined
 ```
 
-But `clicked()` would not:
+But `onclick` would not:
 
 ```js
-Counter.prototype.clicked  // undefined
+Counter.prototype.onclick  // undefined
 ```
 
 It usually makes sense to put mock methods on the prototype, not on each instance separately (and this is how many testing libraries work when you ask them to create a mock or spy method):
 
 ```js
-Counter.prototype.clicked = mockMethod
+Counter.prototype.onclick = mockMethod
 ```
 
-But this prototype method will be ignored, because `this.clicked` takes priority in the prototype chain.
+But this prototype method will be ignored, because `this.onclick` (own property) takes priority in the prototype chain.
 
 ### Inheritance
 
 As we saw above, using arrow functions in class field initializers causes the method to be absent from the prototype. This can lead to unexpected results when using inheritance.
 
-Suppose we have a subclass of `Counter` with its own `clicked` method:
+Suppose we have a subclass of `Counter` with its own `onclick` method:
 
 ```js
 class SpecialCounter extends Counter {
   ...
-  clicked() {
+  onclick() {
     console.log('SpecialCounter clicked');
   }
   ...
 }
 
 const specialCounter = new SpecialCounter();
-// which method gets called?
-specialCounter.clicked();
+// Which method gets called?
+specialCounter.onclick();
+// (Note: this example is for illustrative purposes only, since in the original example, `this.onclick = ...`
+// sets up the event listener for the browser. Among other reasons, this example is not realistic because
+// we're calling onclick() manually here.)
 ```
 
-In the above example, the expectation is that you are calling the `clicked` method in the `SpecialCounter` class, but in fact that method is not called at all because the ES engine first looks for property values in the instance before it looks at the prototype. The method that is actually called is the `clicked` method in the parent `Counter` class.
+In the above example, the expectation is that you are calling the `onclick` method in the `SpecialCounter` class, but in fact that method is not called at all because the ES engine first looks for property values in the instance before it looks at the prototype. The method that is actually called is the `onclick` method in the parent `Counter` class.
 
 `super` calls can also break unexpectedly:
 
 ```js
 class SpecialCounter extends Counter {
   ...
-  clicked = () => {
-    // Uncaught TypeError: (intermediate value).clicked is not a function
-    super.clicked();
+  onclick = () => {
+    // Uncaught TypeError: (intermediate value).onclick is not a function
+    super.onclick();
   }
   ...
+}
+```
+
+### Comparison with `@bind` decorator
+
+Let's consider some alternative implementations of the original example from the readme:
+
+```js
+// Version A
+class Counter extends HTMLElement {
+  constructor() {
+    super();
+    this.onclick = this.#clicked.bind(this);
+  }
+
+  #clicked() {
+    this.#x++;
+  }
+  ...
+}
+
+// Version B
+class Counter extends HTMLElement {
+  onclick = () => {
+    this.#x++;
+  }
+  ...
+}
+
+// Version C
+class Counter extends HTMLElement {
+  onclick = this.#clicked.bind(this);
+
+  #clicked() {
+    this.#x++;
+  }
+  ...
+}
+
+// Version D
+class Counter extends HTMLElement {
+  onclick = this.#clicked;
+
+  @bound
+  #clicked() {
+    this.#x++;
+  }
+  ...
+}
+```
+
+It's generally agreed that concise, expressive code is preferable as long as it doesn't hide important details. From this perspective, versions B and D have the advantage. Version D (using the decorator) is often preferable to version B for the reasons explained above. Version C is the next most concise version that also avoids the issues with arrow functions, but it still requires that you call `bind()` manually for every function you want to bind. This is more obvious in cases where the decorator would allow you to write the method name only once. For example, in React you would not need to assign the method to `onclick` but could use a `handleClick` method directly:
+
+```js
+class Counter extends React.Component {
+  ...
+  @bound
+  handleClick() {
+    this.#x++;
+  }
+
+  render() {
+    return (
+      <div onClick={this.handleClick}>
+        {this.props.children}
+      </div>
+    );
+  }
 }
 ```
 

--- a/METAPROGRAMMING.md
+++ b/METAPROGRAMMING.md
@@ -6,7 +6,7 @@ Previously, metaprogramming within JavaScript was driven by use of dynamic opera
 * Decorators can manipulate private fields and private methods, whereas operations on objects are unable to manipulate the definitions of private names.
 * Decorators do their manipulations at the time the class is defined, rather than when instances are being created and used, so they may lead to patterns which are more amenable to efficient implementation.
 
-As stated in the readme, decorators can be used either to decorate a whole class or an individual class element (field or method). Decorators are implemented as functions which take a JSON-like representation of a class element as an argument and return a possibly-modified form of that, optionally with additional class elements. For both kinds of decorator functions, class elements are represented in the form:
+Dcorators can be used either to decorate a whole class or an individual class element (field or method). Decorators are implemented as functions which take a JSON-like representation of a class element as an argument and return a possibly-modified form of that, optionally with additional class elements. For both kinds of decorator functions, class elements are represented in the form:
 
 ```js
 {
@@ -29,7 +29,7 @@ For private fields, methods or accessors, the `key` will be a Private Name--this
 
 ## Examples
 
-The three decorators from README.md could be defined as follows:
+The three decorators from [README.md](README.md) could be defined as follows:
 
 ```js
 // Define the class as a custom element with the given tag name
@@ -39,7 +39,7 @@ function defineElement(tagName) {
   // when actually decorating the class (manual currying).
   return function(classDescriptor) {
     let { kind, elements } = classDescriptor;
-    assert(kind == 'class');
+    assert(kind == "class");
     return {
       kind,
       elements,
@@ -54,14 +54,14 @@ function defineElement(tagName) {
 // Replace a method with a field with a bound version of the method
 function bound(elementDescriptor) {
   let { kind, key, placement, descriptor } = elementDescriptor;
-  assert(kind === 'method');
-  if (placement == 'prototype') placement = 'own';
+  assert(kind === "method");
+  if (placement == "prototype") placement = "own";
   const { value } = descriptor;
   function initializer() {
     return value.bind(this);
   }
   delete descriptor.value;
-  return { kind: 'field', key, placement, descriptor, initializer };
+  return { kind: "field", key, placement, descriptor, initializer };
 }
 
 // Whenever a read or write is done to a field, call the render()
@@ -75,7 +75,7 @@ function observed({kind, key, placement, descriptor, initializer}, get, set) {
   let underlyingDescriptor = { enumerable: false, configurable: false, writable: true };
   let underlying = { kind, key: storage, placement, descriptor: underlyingDescriptor, initializer };
   return {
-    kind: 'method',
+    kind: "method",
     key,
     placement,
     descriptor: {
@@ -93,180 +93,6 @@ function observed({kind, key, placement, descriptor, initializer}, get, set) {
 }
 ```
 
-<a id="bound-decorator-notes"></a>
 ## Notes about the `@bound` decorator
 
-You may have seen the following pattern for creating bound methods and be wondering why a `@bound` decorator would be preferred over this:
-
-```js
-class Counter extends HTMLElement {
-  @observed #x = 0;
-
-  onclick = () => {
-    this.#x++;
-  }
-
-  ...
-}
-```
-
-This is still a subject of some debate, but there are certainly valid reasons to prefer the decorator implementation:
-
-### Mocking
-
-The arrow function version is equivalent to the following:
-
-```js
-class Counter extends HTMLElement {
-  ...
-
-  constructor() {
-    super();
-    this.onclick = () => this.#x++;
-  }
-
-  ...
-}
-```
-
-Therefore, the `onclick` method no longer exists on the `Counter`'s prototype. Suppose our `Counter` class had a couple other regular methods in addition to `onclick`:
-
-```js
-class Counter extends HTMLElement {
-  ...
-  foo() {...}
-  bar() {...}
-  ...
-}
-```
-
-Then those methods would be defined on the prototype:
-
-```js
-Counter.prototype.foo  // defined
-Counter.prototype.bar  // defined
-```
-
-But `onclick` would not:
-
-```js
-Counter.prototype.onclick  // undefined
-```
-
-It usually makes sense to put mock methods on the prototype, not on each instance separately (and this is how many testing libraries work when you ask them to create a mock or spy method):
-
-```js
-Counter.prototype.onclick = mockMethod
-```
-
-But this prototype method will be ignored, because `this.onclick` (own property) takes priority in the prototype chain.
-
-### Inheritance
-
-As we saw above, using arrow functions in class field initializers causes the method to be absent from the prototype. This can lead to unexpected results when using inheritance.
-
-Suppose we have a subclass of `Counter` with its own `onclick` method:
-
-```js
-class SpecialCounter extends Counter {
-  ...
-  onclick() {
-    console.log('SpecialCounter clicked');
-  }
-  ...
-}
-
-const specialCounter = new SpecialCounter();
-// Which method gets called?
-specialCounter.onclick();
-// (Note: this example is for illustrative purposes only, since in the original example, `this.onclick = ...`
-// sets up the event listener for the browser. Among other reasons, this example is not realistic because
-// we're calling onclick() manually here.)
-```
-
-In the above example, the expectation is that you are calling the `onclick` method in the `SpecialCounter` class, but in fact that method is not called at all because the ES engine first looks for property values in the instance before it looks at the prototype. The method that is actually called is the `onclick` method in the parent `Counter` class.
-
-`super` calls can also break unexpectedly:
-
-```js
-class SpecialCounter extends Counter {
-  ...
-  onclick = () => {
-    // Uncaught TypeError: (intermediate value).onclick is not a function
-    super.onclick();
-  }
-  ...
-}
-```
-
-### Comparison with `@bind` decorator
-
-Let's consider some alternative implementations of the original example from the readme:
-
-```js
-// Version A
-class Counter extends HTMLElement {
-  constructor() {
-    super();
-    this.onclick = this.#clicked.bind(this);
-  }
-
-  #clicked() {
-    this.#x++;
-  }
-  ...
-}
-
-// Version B
-class Counter extends HTMLElement {
-  onclick = () => {
-    this.#x++;
-  }
-  ...
-}
-
-// Version C
-class Counter extends HTMLElement {
-  onclick = this.#clicked.bind(this);
-
-  #clicked() {
-    this.#x++;
-  }
-  ...
-}
-
-// Version D
-class Counter extends HTMLElement {
-  onclick = this.#clicked;
-
-  @bound
-  #clicked() {
-    this.#x++;
-  }
-  ...
-}
-```
-
-It's generally agreed that concise, expressive code is preferable as long as it doesn't hide important details. From this perspective, versions B and D have the advantage. Version D (using the decorator) is often preferable to version B for the reasons explained above. Version C is the next most concise version that also avoids the issues with arrow functions, but it still requires that you call `bind()` manually for every function you want to bind. This is more obvious in cases where the decorator would allow you to write the method name only once. For example, in React you would not need to assign the method to `onclick` but could use a `handleClick` method directly:
-
-```js
-class Counter extends React.Component {
-  ...
-  @bound
-  handleClick() {
-    this.#x++;
-  }
-
-  render() {
-    return (
-      <div onClick={this.handleClick}>
-        {this.props.children}
-      </div>
-    );
-  }
-}
-```
-
-### Counterarguments
-
-Some people argue that the above issues are not sufficient reason to avoid arrow functions in class fields entirely, depending on your app. Obviously, in parts of your app where you are using inheritance, the arguments against arrow functions are more persuasive. There are also performance considerations when choosing between the two approaches. The performance differences are usually negligible but can be more significant in cases where you have hundreds or thousands of instances of a class. If you were to simply use arrow functions everywhere without thinking about the consequences, that could cause problems. Of course the same would be true of careless use of the `@bound` decorator. A full comparison of all the pros and cons in different situations is beyond the scope of this article. Suffice it to say that arrow functions are not an ideal solution in all situations, and the motivation to want a `@bound` decorator is realistic.
+See [bound-decorator-rationale.md](bound-decorator-rationale.md)

--- a/METAPROGRAMMING.md
+++ b/METAPROGRAMMING.md
@@ -93,51 +93,6 @@ function observed({kind, key, placement, descriptor, initializer}, get, set) {
 }
 ```
 
-## Class element finisher
-
-Here is an example that uses the `finisher` property for a class element:
-
-```js
-class User {
-  @readonly id;
-  email;
-
-  constructor(id = null, email = null) {
-    this.id = id;
-    this.email = email;
-  }
-}
-
-function readonly(elementDecriptor) {
-  // we don't want to set `writable` to false until after the property has been initialized
-  elementDecriptor.finisher = () => {
-    elementDecriptor.descriptor.writable = false;
-  };
-  return elementDecriptor;
-}
-```
-
-The above code is functionally equivalent to the following:
-
-```js
-class User {
-  id;
-  email;
-
-  constructor(id = null, email = null) {
-    this.id = id;
-    this.email = email;
-    // finisher
-    Object.defineProperty(this, 'id', {
-      writable: false,
-      // configurable: false and enumerable: true are the default for public class fields
-      configurable: false,
-      enumerable: true
-    });
-  }
-}
-```
-
 <a id="bound-decorator-notes"></a>
 ## Notes about the `@bound` decorator
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ class Counter extends HTMLElement {
 
 Here, decorators are used for:
 - `@defineElement` defines the custom element, allowing the name of the element to be at the beginning of the class
-- `@bound` makes `#clicked` into an auto-bound method, replacing the explicit `bind` call later
+- `@bound` makes `#clicked` into an auto-bound method, replacing the explicit `bind` call later. See also [notes about the `@bound` decorator](METAPROGRAMMING.md#bound-decorator-notes).
 - `@observed` automatically schedules a call to the `render()` method when the `#x` field is changed
 
 You can decorate the whole class, as well as declarations of fields, getters, setters and methods. Arguments and function declarations cannot be decorated.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ class Counter extends HTMLElement {
 
 Here, decorators are used for:
 - `@defineElement` defines the custom element, allowing the name of the element to be at the beginning of the class
-- `@bound` makes `#clicked` into an auto-bound method, replacing the explicit `bind` call later. See also [notes about the `@bound` decorator](METAPROGRAMMING.md#bound-decorator-notes).
+- `@bound` makes `#clicked` into an auto-bound method, replacing the explicit `bind` call later. See also [rationale for the `@bound` decorator](bound-decorator-rationale.md).
 - `@observed` automatically schedules a call to the `render()` method when the `#x` field is changed
 
 You can decorate the whole class, as well as declarations of fields, getters, setters and methods. Arguments and function declarations cannot be decorated.

--- a/bound-decorator-rationale.md
+++ b/bound-decorator-rationale.md
@@ -178,6 +178,31 @@ class Counter extends React.Component {
 }
 ```
 
+Having said all that, the `@bound` decorator does not perfectly prevent all issues relating to bound functions and inheritance. For example, consider this:
+
+```js
+class Parent {
+  @bound
+  foo() {
+    console.log("Parent");
+  }
+}
+
+class Child {
+  constructor() {
+    super();
+    // Logs "Parent", not "Child"
+    this.foo();
+  }
+
+  foo() {
+    console.log("Child");
+  }
+}
+```
+
+But there are still significantly fewer prototype and inheritance-related issues with the `@bound` decorator than there are with fields initialized to arrow functions.
+
 ### Counterarguments
 
 Some people argue that the above issues are not sufficient reason to avoid arrow functions in class fields entirely, depending on your app. Obviously, in parts of your app where you are using inheritance, the arguments against arrow functions are more persuasive. There are also performance considerations when choosing between the two approaches. The performance differences are usually negligible but can be more significant in cases where you have hundreds or thousands of instances of a class. If you were to simply use arrow functions everywhere without thinking about the consequences, that could cause problems. Of course the same would be true of careless use of the `@bound` decorator. A full comparison of all the pros and cons in different situations is beyond the scope of this article. Suffice it to say that arrow functions are not an ideal solution in all situations, and the motivation to want a `@bound` decorator is realistic.

--- a/bound-decorator-rationale.md
+++ b/bound-decorator-rationale.md
@@ -72,8 +72,15 @@ As we saw above, using arrow functions in class field initializers causes the me
 Suppose we have a subclass of `Counter` with its own `onclick` method:
 
 ```js
-class SpecialCounter extends Counter {
+class Counter extends HTMLElement {
   ...
+  onclick = () => {
+    this.#x++;
+  }
+  ...
+}
+
+class SpecialCounter extends Counter {
   onclick() {
     console.log("SpecialCounter clicked");
   }

--- a/bound-decorator-rationale.md
+++ b/bound-decorator-rationale.md
@@ -1,0 +1,176 @@
+# Rationale for the `@bound` decorator
+
+You may have seen the following pattern for creating bound methods and be wondering why a `@bound` decorator would be preferred over this:
+
+```js
+class Counter extends HTMLElement {
+  @observed #x = 0;
+
+  onclick = () => {
+    this.#x++;
+  }
+
+  ...
+}
+```
+
+This is still a subject of some debate, but there are certainly valid reasons to prefer the decorator implementation:
+
+### Mocking
+
+The arrow function version is equivalent to the following:
+
+```js
+class Counter extends HTMLElement {
+  ...
+
+  constructor() {
+    super();
+    this.onclick = () => this.#x++;
+  }
+
+  ...
+}
+```
+
+Therefore, the `onclick` method no longer exists on the `Counter`'s prototype. Suppose our `Counter` class had a couple other regular methods in addition to `onclick`:
+
+```js
+class Counter extends HTMLElement {
+  ...
+  foo() {...}
+  bar() {...}
+  ...
+}
+```
+
+Then those methods would be defined on the prototype:
+
+```js
+Counter.prototype.foo  // defined
+Counter.prototype.bar  // defined
+```
+
+But `onclick` would not:
+
+```js
+Counter.prototype.onclick  // undefined
+```
+
+It usually makes sense to put mock methods on the prototype, not on each instance separately (and this is how many testing libraries work when you ask them to create a mock or spy method):
+
+```js
+Counter.prototype.onclick = mockMethod
+```
+
+But this prototype method will be ignored, because `this.onclick` (own property) takes priority in the prototype chain.
+
+### Inheritance
+
+As we saw above, using arrow functions in class field initializers causes the method to be absent from the prototype. This can lead to unexpected results when using inheritance.
+
+Suppose we have a subclass of `Counter` with its own `onclick` method:
+
+```js
+class SpecialCounter extends Counter {
+  ...
+  onclick() {
+    console.log("SpecialCounter clicked");
+  }
+  ...
+}
+
+const specialCounter = new SpecialCounter();
+// Which method gets called?
+specialCounter.onclick();
+// (Note: this example is for illustrative purposes only, since in the original example, `this.onclick = ...`
+// sets up the event listener for the browser. Among other reasons, this example is not realistic because
+// we're calling onclick() manually here.)
+```
+
+In the above example, the expectation is that you are calling the `onclick` method in the `SpecialCounter` class, but in fact that method is not called at all because the ES engine first looks for property values in the instance before it looks at the prototype. The method that is actually called is the `onclick` method in the parent `Counter` class.
+
+`super` calls can also break unexpectedly:
+
+```js
+class SpecialCounter extends Counter {
+  ...
+  onclick = () => {
+    // Uncaught TypeError: (intermediate value).onclick is not a function
+    super.onclick();
+  }
+  ...
+}
+```
+
+### Comparison with `@bind` decorator
+
+Let's consider some alternative implementations of the original example from the readme:
+
+```js
+// Version A
+class Counter extends HTMLElement {
+  constructor() {
+    super();
+    this.onclick = this.#clicked.bind(this);
+  }
+
+  #clicked() {
+    this.#x++;
+  }
+  ...
+}
+
+// Version B
+class Counter extends HTMLElement {
+  onclick = () => {
+    this.#x++;
+  }
+  ...
+}
+
+// Version C
+class Counter extends HTMLElement {
+  onclick = this.#clicked.bind(this);
+
+  #clicked() {
+    this.#x++;
+  }
+  ...
+}
+
+// Version D
+class Counter extends HTMLElement {
+  onclick = this.#clicked;
+
+  @bound
+  #clicked() {
+    this.#x++;
+  }
+  ...
+}
+```
+
+It's generally agreed that concise, expressive code is preferable as long as it doesn't hide important details. From this perspective, versions B and D have the advantage. Version D (using the decorator) is often preferable to version B for the reasons explained above. Version C is the next most concise version that also avoids the issues with arrow functions, but it still requires that you call `bind()` manually for every function you want to bind. This is more obvious in cases where the decorator would allow you to write the method name only once. For example, in React you would not need to assign the method to `onclick` but could use a `handleClick` method directly:
+
+```js
+class Counter extends React.Component {
+  ...
+  @bound
+  handleClick() {
+    this.#x++;
+  }
+
+  render() {
+    return (
+      <div onClick={this.handleClick}>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+```
+
+### Counterarguments
+
+Some people argue that the above issues are not sufficient reason to avoid arrow functions in class fields entirely, depending on your app. Obviously, in parts of your app where you are using inheritance, the arguments against arrow functions are more persuasive. There are also performance considerations when choosing between the two approaches. The performance differences are usually negligible but can be more significant in cases where you have hundreds or thousands of instances of a class. If you were to simply use arrow functions everywhere without thinking about the consequences, that could cause problems. Of course the same would be true of careless use of the `@bound` decorator. A full comparison of all the pros and cons in different situations is beyond the scope of this article. Suffice it to say that arrow functions are not an ideal solution in all situations, and the motivation to want a `@bound` decorator is realistic.


### PR DESCRIPTION
Fixes #58 and #55.

I can separate these into 2 separate PRs if that's easier. My notes about the `@bound` decorator got a bit lengthy but I felt that was necessary to clearly explain the reasons for it. I'm not sure if they would be better off in a separate file, or if perhaps that level of detail is considered out of scope -- but I do think it would be helpful to some people (it would have been helpful to me when I came to this repo for the first time).