### PR TITLE
Fixed `@observed` example implementation

### DIFF
--- a/METAPROGRAMMING.md
+++ b/METAPROGRAMMING.md
@@ -66,7 +66,7 @@ function observed({kind, key, placement, descriptor, initializer}) {
   let underlyingDescriptor = { enumerable: false, configurable: false, writable: true };
   let underlying = { kind, key: storage, placement, descriptor: underlyingDescriptor, initializer };
   return {
-    kind: "field",
+    kind: "method",
     key,
     placement,
     descriptor: {

--- a/METAPROGRAMMING.md
+++ b/METAPROGRAMMING.md
@@ -64,9 +64,9 @@ function observed({kind, key, placement, descriptor, initializer}) {
   // Create a new anonymous private name as a key for a class element
   let storage = decorators.PrivateName();
   let underlyingDescriptor = { enumerable: false, configurable: false, writable: true };
-  let underlying = { kind, key: storage, placement, underlyingDescriptor, initializer };
+  let underlying = { kind, key: storage, placement, descriptor: underlyingDescriptor, initializer };
   return {
-    kind: "method",
+    kind: "field",
     key,
     placement,
     descriptor: {


### PR DESCRIPTION
I think there are two mistakes in the example implementation of observed:

1. A field `underlyingDescriptor` is introduced on an element descriptor. Probably this should have been `descriptor: underlyingDescriptor`?
2. `@observed` is originally applied to a `field`, but returns a get / settable `method` element descriptor. Probably this should stay a `field` element descriptor?