### PR TITLE
Don't override _descriptor_ in ToClassDescriptor/ToElementDescriptor

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1126,7 +1126,6 @@ emu-example pre {
       <h1>DecorateConstructor ( elements, decorators )</h1>
       <p>With parameters _elements_, a List of Class Elements, and _decorators_, a List of decorator functions.</p>
       <emu-alg>
-        1. Let _elements_ be a new empty List.
         1. Let _finishers_ be a new empty List.
         1. For each _decorator_ in _decorators_, in reverse list order do
           1. Let _obj_ be FromClassDescriptor(_elements_).
@@ -1186,23 +1185,23 @@ emu-example pre {
     </emu-clause>
 
     <emu-clause id=sec-to-element-descriptor aoid=ToElementDescriptor>
-      <h1>ToElementDescriptor ( _descriptor_ )</h1>
-      <p>With parameter _descriptor_, returns a Record containing three values: { [[Element]]: a class Element Descriptor, [[Extras]]: an iterable of other elements, [[Finisher]]: a Function or *undefined* }.</p>
+      <h1>ToElementDescriptor ( _elementObject_ )</h1>
+      <p>With parameter _elementObject_, returns a Record containing three values: { [[Element]]: a class Element Descriptor, [[Extras]]: an iterable of other elements, [[Finisher]]: a Function or *undefined* }.</p>
       <emu-alg>
-        1. Let _kind_ be ? ToString(? Get(_descriptor_, `"kind"`)).
+        1. Let _kind_ be ? ToString(? Get(_elementObject_, `"kind"`)).
         1. If _kind_ is not one of `"method"` or `"field"`, throw a *TypeError* exception.
-        1. Let _key_ be ? Get(_descriptor_, `"key"`).
+        1. Let _key_ be ? Get(_elementObject_, `"key"`).
         1. Set _key_ to ? ToPrimitive(_key_, hint String).
         1. If _key_ is not a Private Name, set _key_ to ? ToPropertyKey(_key_).
-        1. Let _placement_ be ? ToString(? Get(_descriptor_, `"placement"`)).
+        1. Let _placement_ be ? ToString(? Get(_elementObject_, `"placement"`)).
         1. If _placement_ is not one of `"static"`, `"prototype"`, or `"own"`, throw a *TypeError* exception.
-        1. Let _descriptor_ be ? ToPropertyDescriptor(? Get(_descriptor_, `"descriptor"`)).
-        1. Let _initializer_ be ? Get(_descriptor_, `"initializer"`).
-        1. Let _finisher_ be ? Get(_descriptor_, `"finisher"`).
+        1. Let _descriptor_ be ? ToPropertyDescriptor(? Get(_elementObject_, `"descriptor"`)).
+        1. Let _initializer_ be ? Get(_elementObject_, `"initializer"`).
+        1. Let _finisher_ be ? Get(_elementObject_, `"finisher"`).
         1. If IsCallable(_finisher_) is *false* and _finisher_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _extrasObject_ be ? Get(_descriptor_, `"extras"`).
+        1. Let _extrasObject_ be ? Get(_elementObject_, `"extras"`).
         1. Let _extras_ be ? ToElementDescriptors(_extrasObject_).
-        1. Let _elements_ be ? Get(_descriptor_, `"elements"`).
+        1. Let _elements_ be ? Get(_elementObject_, `"elements"`).
         1. If _elements_ is not *undefined*, throw a *TypeError* exception.
         1. If _kind_ not `"field"`,
           1. If _initializer_ is not *undefined*, throw a *TypeError* exception.
@@ -1234,22 +1233,22 @@ emu-example pre {
     <emu-clause id=sec-to-class-descriptor aoid=ToClassDescriptor>
       <h1>ToClassDescriptor ( _obj_ )</h1>
       <emu-alg>
-        1. Let _kind_ be ? ToString(? Get(_descriptor_, `"kind"`).
+        1. Let _kind_ be ? ToString(? Get(_obj_, `"kind"`).
         1. If _kind_ is not `"class"`, throw a *TypeError* exception.
-        1. Let _key_ be ? Get(_descriptor_, `"key"`).
+        1. Let _key_ be ? Get(_obj_, `"key"`).
         1. If _key_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _placement_ be ? Get(_descriptor_, `"placement"`).
+        1. Let _placement_ be ? Get(_obj_, `"placement"`).
         1. If _placement_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _descriptor_ be ? Get(_descriptor_, `"descriptor"`).
+        1. Let _descriptor_ be ? Get(_obj_, `"descriptor"`).
         1. If _descriptor_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _initializer_ be ? Get(_descriptor_, `"initializer"`).
+        1. Let _initializer_ be ? Get(_obj_, `"initializer"`).
         1. If _initializer_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _extras_ be ? Get(_extras_, `"initializer"`).
+        1. Let _extras_ be ? Get(_obj_, `"extras"`).
         1. If _extras_ is not *undefined*, throw a *TypeError* exception.
         1. Let _finisher_ be ? Get(_obj_, `"finisher"`).
         1. If _finisher_ is not *undefined*,
           1. If IsCallable(_finisher_) is *false*, throw a *TypeError* exception.
-        1. Let _elementsObject_ be ? Get(_result_, `"elements"`).
+        1. Let _elementsObject_ be ? Get(_obj_, `"elements"`).
         1. Let _elements_ be ? ToElementDescriptors(_elementsObject_).
         1. Return the Record { [[Elements]]: _elements_, [[Finisher]]: _finisher_ }.
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -1173,35 +1173,35 @@ emu-example pre {
     </emu-clause>
 
     <emu-clause id="sec-to-element-descriptors" aoid=ToElementDescriptor>
-      <h1>ToElementDescriptors ( _elementsObject_ )</h1>
+      <h1>ToElementDescriptors ( _elementDescriptors_ )</h1>
       <emu-alg>
-        1. If _elementsObject_ is *undefined*, return *undefined*.
+        1. If _elementDescriptors_ is *undefined*, return *undefined*.
         1. Let _elements_ be a new empty List.
-        1. Let _elementObjectList_ be ? IterableToList(_elementsObject_).
-        1. For each _elementObject_ in _elementObjectList_, do
-          1. Append ToElementDescriptor(_elementObject_) to _elements_.
+        1. Let _elementDescriptorList_ be ? IterableToList(_elementDescriptors_).
+        1. For each _elementDescriptor_ in _elementDescriptorList_, do
+          1. Append ToElementDescriptor(_elementDescriptor_) to _elements_.
         1. Return _elements_.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id=sec-to-element-descriptor aoid=ToElementDescriptor>
-      <h1>ToElementDescriptor ( _elementObject_ )</h1>
-      <p>With parameter _elementObject_, returns a Record containing three values: { [[Element]]: a class Element Descriptor, [[Extras]]: an iterable of other elements, [[Finisher]]: a Function or *undefined* }.</p>
+      <h1>ToElementDescriptor ( _elementDescriptor_ )</h1>
+      <p>With parameter _elementDescriptor_, returns a Record containing three values: { [[Element]]: a class Element Descriptor, [[Extras]]: an iterable of other elements, [[Finisher]]: a Function or *undefined* }.</p>
       <emu-alg>
-        1. Let _kind_ be ? ToString(? Get(_elementObject_, `"kind"`)).
+        1. Let _kind_ be ? ToString(? Get(_elementDescriptor_, `"kind"`)).
         1. If _kind_ is not one of `"method"` or `"field"`, throw a *TypeError* exception.
-        1. Let _key_ be ? Get(_elementObject_, `"key"`).
+        1. Let _key_ be ? Get(_elementDescriptor_, `"key"`).
         1. Set _key_ to ? ToPrimitive(_key_, hint String).
         1. If _key_ is not a Private Name, set _key_ to ? ToPropertyKey(_key_).
-        1. Let _placement_ be ? ToString(? Get(_elementObject_, `"placement"`)).
+        1. Let _placement_ be ? ToString(? Get(_elementDescriptor_, `"placement"`)).
         1. If _placement_ is not one of `"static"`, `"prototype"`, or `"own"`, throw a *TypeError* exception.
-        1. Let _descriptor_ be ? ToPropertyDescriptor(? Get(_elementObject_, `"descriptor"`)).
-        1. Let _initializer_ be ? Get(_elementObject_, `"initializer"`).
-        1. Let _finisher_ be ? Get(_elementObject_, `"finisher"`).
+        1. Let _descriptor_ be ? ToPropertyDescriptor(? Get(_elementDescriptor_, `"descriptor"`)).
+        1. Let _initializer_ be ? Get(_elementDescriptor_, `"initializer"`).
+        1. Let _finisher_ be ? Get(_elementDescriptor_, `"finisher"`).
         1. If IsCallable(_finisher_) is *false* and _finisher_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _extrasObject_ be ? Get(_elementObject_, `"extras"`).
+        1. Let _extrasObject_ be ? Get(_elementDescriptor_, `"extras"`).
         1. Let _extras_ be ? ToElementDescriptors(_extrasObject_).
-        1. Let _elements_ be ? Get(_elementObject_, `"elements"`).
+        1. Let _elements_ be ? Get(_elementDescriptor_, `"elements"`).
         1. If _elements_ is not *undefined*, throw a *TypeError* exception.
         1. If _kind_ not `"field"`,
           1. If _initializer_ is not *undefined*, throw a *TypeError* exception.
@@ -1231,24 +1231,24 @@ emu-example pre {
     </emu-clause>
 
     <emu-clause id=sec-to-class-descriptor aoid=ToClassDescriptor>
-      <h1>ToClassDescriptor ( _obj_ )</h1>
+      <h1>ToClassDescriptor ( _classDescriptor_ )</h1>
       <emu-alg>
-        1. Let _kind_ be ? ToString(? Get(_obj_, `"kind"`).
+        1. Let _kind_ be ? ToString(? Get(_classDescriptor_, `"kind"`).
         1. If _kind_ is not `"class"`, throw a *TypeError* exception.
-        1. Let _key_ be ? Get(_obj_, `"key"`).
+        1. Let _key_ be ? Get(_classDescriptor_, `"key"`).
         1. If _key_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _placement_ be ? Get(_obj_, `"placement"`).
+        1. Let _placement_ be ? Get(_classDescriptor_, `"placement"`).
         1. If _placement_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _descriptor_ be ? Get(_obj_, `"descriptor"`).
+        1. Let _descriptor_ be ? Get(_classDescriptor_, `"descriptor"`).
         1. If _descriptor_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _initializer_ be ? Get(_obj_, `"initializer"`).
+        1. Let _initializer_ be ? Get(_classDescriptor_, `"initializer"`).
         1. If _initializer_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _extras_ be ? Get(_obj_, `"extras"`).
+        1. Let _extras_ be ? Get(_classDescriptor_, `"extras"`).
         1. If _extras_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _finisher_ be ? Get(_obj_, `"finisher"`).
+        1. Let _finisher_ be ? Get(_classDescriptor_, `"finisher"`).
         1. If _finisher_ is not *undefined*,
           1. If IsCallable(_finisher_) is *false*, throw a *TypeError* exception.
-        1. Let _elementsObject_ be ? Get(_obj_, `"elements"`).
+        1. Let _elementsObject_ be ? Get(_classDescriptor_, `"elements"`).
         1. Let _elements_ be ? ToElementDescriptors(_elementsObject_).
         1. Return the Record { [[Elements]]: _elements_, [[Finisher]]: _finisher_ }.
       </emu-alg>


### PR DESCRIPTION
I found this bug while working on the Babel plugin the `_descriptor_` variable was used both for the parameter and for it's `descriptor` property.

Do I have to sign a CLA?