### PR TITLE
Normative: Pass %PrivateName% into element decorators

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -658,7 +658,7 @@ emu-example pre {
         1. For each _decorator_ in _element_.[[Decorators]], in reverse list order do
           1. Perform RemoveElementPlacement(_element_, _placements_).
           1. Let _elementObject_ be ? FromElementDescriptor(_element_).
-          1. Let _elementFinisherExtrasObject_ be ? Call(_decorator_, *undefined*, « _elementObject_, %PrivateNameGet%, %PrivateNameSet% »).
+          1. Let _elementFinisherExtrasObject_ be ? Call(_decorator_, *undefined*, « _elementObject_, %PrivateName% »).
           1. If _elementFinisherExtrasObject_ is *undefined*, 
             1. Let _elementFinisherExtrasObject_ be _elementObject_.
           1. Let _elementFinisherExtras_ be ? ToElementFinisherExtras(_elementFinisherExtrasObject_).


### PR DESCRIPTION
The PrivateName constructor is passed as the second argument
to decorators, starting from
828634dd821a9c764ac389bdb8b3a2b3c74699ca
That patch omitted element decorators from the change; this patch
fixes the error.