### PR TITLE
Normative: Remove PrivateName constructor from decorators

### DIFF
--- a/METAPROGRAMMING.md
+++ b/METAPROGRAMMING.md
@@ -185,11 +185,11 @@ function bound(elementDescriptor) {
 // Whenever a read or write is done to a field, call the render()
 // method afterwards. Implement this by replacing the field with
 // a getter/setter pair.
-function observed({kind, key, placement, descriptor, initializer}, PrivateName) {
+function observed({kind, key, placement, descriptor, initializer}) {
   assert(kind == "field");
   assert(placement == "own");
   // Create a new anonymous private name as a key for a class element
-  let storage = new PrivateName();
+  let storage = PrivateName();
   let underlyingDescriptor = { enumerable: false, configurable: false, writable: true };
   let underlying = { kind, key: storage, placement, descriptor: underlyingDescriptor, initializer };
   return {
@@ -208,6 +208,15 @@ function observed({kind, key, placement, descriptor, initializer}, PrivateName) 
     },
     extras: [underlying]
   };
+}
+
+// There is no built-in PrivateName constructor, but a new private name can
+// be constructed by extracting it from a throwaway class
+function PrivateName() {
+  let name;
+  function extract({key}) { name = key; }
+  class Throwaway { @extract #_; }
+  return name;
 }
 ```
 

--- a/friend.js
+++ b/friend.js
@@ -20,7 +20,7 @@ class PrivateNameMap {
         klass = Object.getPrototypeOf(klass);
         continue;
       } else {
-        assert(typeof possibleKey === "privatename");
+        assert(typeof possibleKey === "object");
         return possibleKey;
       }
     }
@@ -52,7 +52,7 @@ let exposeMap = new PrivateNameMap;
 // Make #foo available to subclasses.
 export function expose(descriptor) {
   let key = descriptor.key;
-  if (typeof key !== "privatename")
+  if (typeof key !== "object")
     throw new TypeError("@expose must be used on #private declarations");
   return {
     finisher(klass) {
@@ -67,7 +67,7 @@ export function expose(descriptor) {
 export function inherit(descriptor) {
   let key = descriptor.key;
   let placement = descriptor.placement;
-  if (typeof key !== "privatename" ||
+  if (typeof key !== "object" ||
       descriptor.kind !== "field" ||
       descriptor.initializer !== undefined) {
     throw new TypeError("invalid declaration for @inherit");
@@ -139,7 +139,7 @@ export class FriendKey {
   expose = descriptor => {
     let key = descriptor.key;
     let string = key.toString();
-    if (typeof key !== "privatename") {
+    if (typeof key !== "object") {
       throw new TypeError(
         "@expose may only be used with private class elements");
     }
@@ -196,7 +196,7 @@ export function abstract(descriptor) {
   let isMethod = descriptor.kind === "method" &&
                  descriptor.value !== undefined;
   let value = descriptor.value;
-  if (typeof key !== "privatename" ||
+  if (typeof key !== "object" ||
       !(isPure || isMethod) ||
       descriptor.placement !== "own") {
    throw new TypeError("invalid declaration for @abstract");
@@ -237,7 +237,7 @@ export function abstract(descriptor) {
 export function override(descriptor) {
   let key = descriptor.key;
   let placement = descriptor.placement;
-  if (typeof key !== "privatename" ||
+  if (typeof key !== "object" ||
       descriptor.kind === "field" ||
       placement !== "own") {
     throw new TypeError("invalid declaration for @override");

--- a/spec.html
+++ b/spec.html
@@ -448,28 +448,16 @@ emu-example pre {
 
 </emu-clause>
 
-  <emu-clause id="sec-private-name-type-and-objects">
-    <h1>PrivateName Objects</h1>
+  <emu-clause id="sec-private-names">
+    <h1>Private Names and references</h1>
 
     <emu-note type=editor>
       This section refers to <a href="https://tc39.github.io/proposal-class-fields/#sec-private-names">Private Name values</a>, as defined in the class fields proposal.
     </emu-note>
 
     <emu-clause id="sec-private-name-constructor">
-      <h1>The %PrivateName% factory function</h1>
-      <p>The Private Name factory function is the <dfn>%PrivateName%</dfn> intrinsic object. When %PrivateName% is called, it returns a new object which wraps a Private Name value. The %PrivateName% intrinsic does not have a global name or appear as a property of the global object.</p>
-
-      <emu-clause id="sec-private-description" aoid=PrivateName>
-        <h1>%PrivateName% ( [ _description_ ] )</h1>
-        <p>When %PrivateName% is called with optional argument _description_, the following steps are taken:</p>
-        <emu-alg>
-          1. If NewTarget is not *undefined*, throw a *TypeError* exception.
-          1. If _description_ is *undefined*, let _descString_ be *undefined*.
-          1. Else, let _descString_ be ? ToString(_description_).
-          1. Let _name_ be NewPrivateName(_descString_).
-          1. Return ? PrivateNameObject(_name_).
-        </emu-alg>
-      </emu-clause>
+      <h1>Private Name objects</h1>
+      <p>Private Name objects are exposed to decorators when decorating a private class element, or a class with private class elements. There is no explicit constructor to create a new Private Name Object.</p>
 
       <emu-clause id="sec-private-name-object" aoid=PrivateNameObject>
         <h1>PrivateNameObject ( _name_ )</h1>
@@ -486,39 +474,38 @@ emu-example pre {
           1. Return _O_.
         </emu-alg>
       </emu-clause>
-    </emu-clause>
 
 
-    <emu-clause id="sec-private-name-get" aoid="%PrivateNameGet%">
-      <h1>%PrivateNameGet% ( _object_ )</h1>
-      <p>When invoked, the following steps are taken:</p>
-      <emu-alg>
-        1. Let _O_ be the *this* value.
-        1. Let _pn_ be ? GetPrivateName(_O_).
-        1. If Type(_object_) is not Object, throw a *TypeError* exception.
-        1. Return ? PrivateFieldGet(_pn_, _object_).
-      </emu-alg>
-    </emu-clause>
+      <emu-clause id="sec-private-name-get" aoid="%PrivateNameGet%">
+        <h1>%PrivateNameGet% ( _object_ )</h1>
+        <p>When invoked, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Let _pn_ be ? GetPrivateName(_O_).
+          1. If Type(_object_) is not Object, throw a *TypeError* exception.
+          1. Return ? PrivateFieldGet(_pn_, _object_).
+        </emu-alg>
+      </emu-clause>
 
-    <emu-clause id="sec-private-name-set" aoid="%PrivateNameSet%">
-      <h1>%PrivateNameSet%( _object_, _value_ )</h1>
-      <p>%PrivateNameSet% is a per-realm built-in function object. When invoked, the following steps are taken:</p>
-      <emu-alg>
-        1. Let _O_ be the *this* value.
-        1. Let _pn_ be ? GetPrivateName(_O_).
-        1. If Type(_object_) is not Object, throw a *TypeError* exception.
-        1. Return ? PrivateFieldSet(_pn_, _object_, _value_).
-      </emu-alg>
-    </emu-clause>
+      <emu-clause id="sec-private-name-set" aoid="%PrivateNameSet%">
+        <h1>%PrivateNameSet%( _object_, _value_ )</h1>
+        <p>%PrivateNameSet% is a per-realm built-in function object. When invoked, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Let _pn_ be ? GetPrivateName(_O_).
+          1. If Type(_object_) is not Object, throw a *TypeError* exception.
+          1. Return ? PrivateFieldSet(_pn_, _object_, _value_).
+        </emu-alg>
+      </emu-clause>
 
-    <emu-clause id="sec-private-name-this-private-name" aoid=ThisPrivateName>
-      <h1>GetPrivateName ( _O_ )</h1>
-      <emu-alg>
-        1. If Type(_O_) is not Object, throw a *TypeError* exception.
-        1. If _O_ does not have a [[PrivateNameData]] internal slot, throw a *TypeError* exception.
-        1. Return _O_.[[PrivateNameData]].
-      </emu-alg>
-    </emu-clause>
+      <emu-clause id="sec-private-name-this-private-name" aoid=ThisPrivateName>
+        <h1>GetPrivateName ( _O_ )</h1>
+        <emu-alg>
+          1. If Type(_O_) is not Object, throw a *TypeError* exception.
+          1. If _O_ does not have a [[PrivateNameData]] internal slot, throw a *TypeError* exception.
+          1. Return _O_.[[PrivateNameData]].
+        </emu-alg>
+      </emu-clause>
 
   </emu-clause>
 </emu-clause>
@@ -626,7 +613,7 @@ emu-example pre {
         1. For each _decorator_ in _element_.[[Decorators]], in reverse list order do
           1. Perform RemoveElementPlacement(_element_, _placements_).
           1. Let _elementObject_ be ? FromElementDescriptor(_element_).
-          1. Let _elementFinisherExtrasObject_ be ? Call(_decorator_, *undefined*, « _elementObject_, %PrivateName% »).
+          1. Let _elementFinisherExtrasObject_ be ? Call(_decorator_, *undefined*, « _elementObject_ »).
           1. If _elementFinisherExtrasObject_ is *undefined*, 
             1. Let _elementFinisherExtrasObject_ be _elementObject_.
           1. Let _elementFinisherExtras_ be ? ToElementFinisherExtras(_elementFinisherExtrasObject_).
@@ -650,7 +637,7 @@ emu-example pre {
         1. Let _finishers_ be a new empty List.
         1. For each _decorator_ in _decorators_, in reverse list order do
           1. Let _obj_ be FromClassDescriptor(_elements_).
-          1. Let _result_ be ? Call(_decorator_, *undefined*, « _obj_, %PrivateName% »).
+          1. Let _result_ be ? Call(_decorator_, *undefined*, « _obj_ »).
           1. If _result_ is *undefined*, let _result_ be _obj_.
           1. Let _elementsAndFinisher_ be ? ToClassDescriptor(_result_).
           1. If _elementsAndFinisher_.[[Finisher]] is not *undefined*,


### PR DESCRIPTION
The constructor can be polyfilled in 5 lines of code; there may
be a cleaner way to include it in the standard library in the
future, or it may be made unnecessary in favor of certain future
syntax. Therefore, it is not necessary to pass it as the second
argument for all decorators.

This patch also updates the code samples in the documentation
(some of which was a bit out of date).

This PR addresses some comments by @caridy in #124.