### PR TITLE
Normative: Restrict the use of PrivateNames in class decorators

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -438,11 +438,12 @@ emu-example pre {
       </emu-clause>
 
       <emu-clause id="sec-private-name-object" aoid=PrivateNameObject>
-        <h1>PrivateNameObject ( _name_ )</h1>
+        <h1>PrivateNameObject ( _name_, _restricted_ )</h1>
         <p>When PrivateNameObject is called with Private Name _name_, the following steps are taken:</p>
         <emu-alg>
-          1. Let _O_ be ? ObjectCreate(%PrivateNamePrototype%, &laquo; [[PrivateName]] &raquo;).
+          1. Let _O_ be ? ObjectCreate(%PrivateNamePrototype%, &laquo; [[PrivateNameData]], [[PrivateNameRestricted]] &raquo;).
           1. Set _O_.[[PrivateNameData]] to _name_.
+          1. Set _O_.[[PrivateNameRestricted]] to _restricted_.
           1. Perform ! SetIntegrityLevel(_O_, `"frozen"`).
           1. Return _O_.
         </emu-alg>
@@ -464,6 +465,7 @@ emu-example pre {
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Let _pn_ be ? GetPrivateName(_O_).
+          1. If _pn_.[[PrivateNameRestricted]] is *true*, throw a *TypeError* exception.
           1. If Type(_object_) is not Object, throw a *TypeError* exception.
           1. Return ? PrivateFieldGet(_pn_, _object_).
         </emu-alg>
@@ -475,6 +477,7 @@ emu-example pre {
         <emu-alg>
           1. Let _O_ be the *this* value.
           1. Let _pn_ be ? GetPrivateName(_O_).
+          1. If _pn_.[[PrivateNameRestricted]] is *true*, throw a *TypeError* exception.
           1. If Type(_object_) is not Object, throw a *TypeError* exception.
           1. Return ? PrivateFieldSet(_pn_, _object_, _value_).
         </emu-alg>
@@ -521,7 +524,7 @@ emu-example pre {
 
     <emu-clause id="sec-properties-of-private-name-instances">
       <h1>Properties of PrivateName Instances</h1>
-      <p>PrivateName instances are ordinary objects that inherit properties from the PrivateName prototype object. PrivateName instances have a [[PrivateNameData]] internal slot. The [[PrivateNameData]] internal slot is the Private Name value represented by this Private Name object.</p>
+      <p>PrivateName instances are ordinary objects that inherit properties from the PrivateName prototype object. PrivateName instances have [[PrivateNameData]] and [[PrivateNameRestricted]] internal slots. The [[PrivateNameData]] internal slot is the Private Name value represented by this Private Name object. [[PrivateNameRestricted]] is a boolean, indicating whether `get` and `set` operations are permitted. </p>
     </emu-clause>
     </emu-clause>
   </emu-clause>
@@ -657,7 +660,7 @@ emu-example pre {
         1. Let _finishers_ be a new empty List.
         1. For each _decorator_ in _element_.[[Decorators]], in reverse list order do
           1. Perform RemoveElementPlacement(_element_, _placements_).
-          1. Let _elementObject_ be ? FromElementDescriptor(_element_).
+          1. Let _elementObject_ be ? FromElementDescriptor(_element_, *false*).
           1. Let _elementFinisherExtrasObject_ be ? Call(_decorator_, *undefined*, « _elementObject_ »).
           1. If _elementFinisherExtrasObject_ is *undefined*, 
             1. Let _elementFinisherExtrasObject_ be _elementObject_.
@@ -731,13 +734,13 @@ emu-example pre {
           1. Assert: _elements_ is a List of ElementDescriptor Records.
           1. Let _elementObjects_ be a new empty List.
           1. For each _element_ in _elements_, do
-            1. Append ! FromElementDescriptor(_element_) to _elementObjects_.
+            1. Append ! FromElementDescriptor(_element_, *true*) to _elementObjects_.
           1. Return ! CreateArrayFromList(_elementObjects_).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id=sec-from-element-descriptor aoid=FromElementDescriptor>
-      <h1>FromElementDescriptor ( _element_ )</h1>
+      <h1>FromElementDescriptor ( _element_, _restricted_ )</h1>
       <emu-alg>
         1. Assert: _element_ is an ElementDescriptor Record.
         1. Let _obj_ be ! ObjectCreate(%ObjectPrototype%).
@@ -745,7 +748,7 @@ emu-example pre {
         1. Perform ! DefinePropertyOrThrow(_obj_, @@toStringTag, _desc_).
         1. Perform ! CreateDataPropertyOrThrow(_obj_, `"kind"`, _element_.[[Kind]]).
         1. Let _key_ be _element_.[[Key]].
-        1. If _key_ is a Private Name, set _key_ to ? PrivateNameObject(_key_).
+        1. If _key_ is a Private Name, set _key_ to ? PrivateNameObject(_key_, _restricted_).
         1. Perform ! CreateDataPropertyOrThrow(_obj_, `"key"`, _key_).
         1. Perform ! CreateDataPropertyOrThrow(_obj_, `"placement"`, _element_.[[Placement]]).
         1. Perform ! CreateDataPropertyOrThrow(_obj_, `"descriptor"`, ! FromPropertyDescriptor(_element_.[[Descriptor]])).


### PR DESCRIPTION
There's been some concern about the trust involved in decorating
private class elements. Decorating a private field or method is
specified to give access to the private name which is declared.
Although this notion of privacy may be defensible in theory, we
take a couple additional precautions to ensure that it's private
in practice:
- #134: PrivateName is a defensive class, which is deeply frozen and
  does not permit monkey patching.
- #133: Class decorators get "restricted" PrivateName instances,
  which cannot be used to read or write private class elements.

Previously, the idea was that class decorators would be trusted,
enabling class decorators to be used to deliberately grant access to
private fields and methods to things outside of the class. For
example, a @testable decorator could expose all private class elements
to a testing framework.

The new idea is, class decorators are less trusted, and can only see
that private class elements are present, insert or delete them, but
not read or write them. This increases the level of privacy in
practice (e.g., if a decorator is used for wrapping purposes and not
expected to be able to trusted reading private fields), but removes
certain use cases.

This patch enables class decorators to add and remove private elements,
which may be considered to have integrity implications with respect
to usages of private class elements as a "brand". The trust level of
class decorators is intermediate: they are trusted with these branding
rights, but not with the ability to actually read and write everything.

In a follow-on proposal, we could permit class decorators to get
un-restricted private names through a `@trusted: decorator` syntax;
we could also decide to "relax" the restriction on all class
decorators.

The logic here could be used to implement "restricted" private fields
as proposed in https://github.com/tc39/proposal-decorators/issues/24#issuecomment-405377193
with the following implementation:

```js
function restricted(privateName) {
  let restrictedName;
  function classDecorator({[{key}]}) {
    restrictedName = key;
  }
  function elementDecorator(descriptor) {
    return {...descriptor, key: privateName};
  }
  @classDecorator class X {
    @elementDecorator x;
  }
  return restrictedName;
}
```