### PR TITLE
Normative: Remove class decorator access to private names

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -681,14 +681,16 @@ emu-example pre {
       <emu-alg>
         1. Let _finishers_ be a new empty List.
         1. For each _decorator_ in _decorators_, in reverse list order do
-          1. Let _obj_ be FromClassDescriptor(_elements_).
+          1. Let _privateElements_ be a List consisting of the ordered subsequence of _elements_ for each _element_ where _element_.[[Key]] is a Private Name.
+          1. Let _publicElements_ be a List consisting of the ordered subsequence of _elements_ for each _element_ where _element_.[[Key]] is not a Private Name.
+          1. Let _obj_ be FromClassDescriptor(_publicElements_).
           1. Let _result_ be ? Call(_decorator_, *undefined*, « _obj_ »).
           1. If _result_ is *undefined*, let _result_ be _obj_.
           1. Let _elementsAndFinisher_ be ? ToClassDescriptor(_result_).
           1. If _elementsAndFinisher_.[[Finisher]] is not *undefined*,
             1. Append _elementsAndFinisher_.[[Finisher]] to _finishers_.
           1. If _elementsAndFinisher_.[[Elements]] is not *undefined*,
-            1. Set _elements_ to _elementsAndFinisher_.[[Elements]].
+            1. Set _elements_ to the concatenation of _elementsAndFinisher_.[[Elements]] and _privateElements_.
             1. If there are two class elements _a_ and _b_ in _elements_ such that _a_.[[Key]] is _b_.[[Key]] and _a_.[[Placement]] is _b_.[[Placement]], throw a *TypeError* exception.
         1. Return the Record { [[Elements]]: _elements_, [[Finishers]]: _finishers_ }.
       </emu-alg>


### PR DESCRIPTION
This patch makes it so that class decorators do not see private
class elements. With this patch, only element decorators have
the ability to do metaprogramming on private class elements.

For field/method decorators, granting access to the private name
seems syntactically clear and implied by the construct. There
are also several critical use cases, including:
- Limited-capability accessors (`@reader`)
- Observation pattern (`@tracked`)
- Friends/testable (`@testable`)

For access from class decorators to private, different people
have had different intuitions: Some expect access, while others
say it violates privacy. A workaround here, under this patch,
is to use an element decorator for each private element, rather
than a class decorator, to accomplish the same thing. This
may be ugly, but it works for all the use cases I'm aware of.

As a possible follow-on proposal, a specifically "trusted"
type of decorator could be created, though the details are unclear.

See #133