### PR TITLE
[ Fix ]  Wrong examples of `initializer` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This introductory document proposes a combined vision for how the proposed class
 
 This page is an overview of the features and their interaction from a user perspective. For detailed semantics, see [DETAILS.md](https://github.com/tc39/proposal-decorators/blob/master/DETAILS.md). Decorators were previously developed [in this repository](https://github.com/tc39/proposal-decorators-previous/).
 
+[Reference implementation (Babel 7)](https://www.npmjs.com/package/@babel/plugin-proposal-decorators)
+
 ## A guiding example: Custom elements with classes
 
 To define a counter widget which increments when clicked, you can define the following with ES2015:

--- a/TAXONOMY.md
+++ b/TAXONOMY.md
@@ -58,11 +58,11 @@ Decorator reification
   key: "foo",
   placement: "static",
   descriptor: {
-    initializer: () => bar;
     writable: true,
     enumerable: true,
     configurable: true
-  }
+  },
+  initializer: () => bar
 }
 ```
 
@@ -151,11 +151,11 @@ Decorator reification
   key: "foo",
   placement: "own",
   descriptor: {
-    initializer: () => bar;
     writable: true,
     enumerable: true,
     configurable: true
-  }
+  },
+  initializer: () => bar
 }
 ```
 
@@ -246,11 +246,11 @@ Decorator reification
   key: decorators.PrivateName("foo"),
   placement: "static",
   descriptor: {
-    initializer: () => bar;
     writable: false,
     enumerable: false,
     configurable: false
-  }
+  },
+  initializer: () => bar
 }
 ```
 
@@ -335,11 +335,11 @@ Decorator reification:
   key: decorators.PrivateName("foo"),
   placement: "own",
   descriptor: {
-    initializer: () => bar;
     writable: true,
     enumerable: false,
     configurable: false
-  }
+  },
+  initializer: () => bar
 }
 ```
 


### PR DESCRIPTION
 - [x] [ Fix ]  Wrong examples of `initializer` property
 - [x] [ Add ]  A link to the Babel plugin