### PR TITLE
Resolve #152 - remove obsolete 'constructor'

### DIFF
--- a/METAPROGRAMMING.md
+++ b/METAPROGRAMMING.md
@@ -131,7 +131,6 @@ A class descriptor with the following properties:
 ```js
 {
   elements: Possibly modified class elements (can include additional class elements)
-  constructor: (optional) The function which should act as the construtor
   finisher: (optional) A callback that is called at the end of class creation
 }
 ```


### PR DESCRIPTION
The spec itself and DETAILS.md suggest that the `constructor` property of a class descriptor is no longer present in the spec. It seems that it was an omission to leave it in this doc.