### PR TITLE
Normative: Remove errant ToPrimitive

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -783,7 +783,6 @@ emu-example pre {
         1. Let _kind_ be ? ToString(? Get(_elementObject_, `"kind"`)).
         1. If _kind_ is not one of `"method"` or `"field"`, throw a *TypeError* exception.
         1. Let _key_ be ? Get(_elementObject_, `"key"`).
-        1. Set _key_ to ? ToPrimitive(_key_, hint String).
         1. If _key_ has a [[PrivateName]] internal slot, set _key_ to _key_.[[PrivateName]].
         1. Otherwise, set _key_ to ? ToPropertyKey(_key_).
         1. Let _placement_ be ? ToString(? Get(_elementObject_, `"placement"`)).


### PR DESCRIPTION
Looks like this ToPrimitive call is a relic from back when PrivateName
was a primitive type. Now that it's an object, and toString() throws,
the result would be that an exception would be thrown on this line.
Furthermore, it's redundant given the following ToPropertyKey call.
This patch simply removes the ToPrimitive operation.