### PR TITLE
Normative: Decorating the constructor is an early error

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -136,6 +136,18 @@ emu-example pre {
         `export` `default` [lookahead &lt;! {`function`, `async` [no |LineTerminator| here] `function`, `class`, <ins>`@`</ins>}] AssignmentExpression[+In, ~Yield, ~Await] `;`
     </emu-grammar>
   </emu-clause>
+
+  <emu-clause id="sec-syntax-early-errors">
+    <h1>Static Semantics: Early Errors</h1>
+    <emu-grammar>
+        DecoratorList[?Yield, ?Await]? MethodDefinition[?Yield, ?Await]
+    </emu-grammar>
+    <ul>
+      <li>
+        It is a Syntax Error if |DecoratorList| is present and PropName of |MethodDefinition| is `"constructor"`.
+      </li>
+    </ul>
+  </emu-clause>
 </emu-clause>
 
 <emu-clause id="sec-new-ecmascript-specification-types">


### PR DESCRIPTION
This proposal doesn't give useful semantics to that construction,
though it might be provided in a follow-on proposal.
Within this proposal, it makes the most sense to create an early
error.

Addresses part of #189