### PR TITLE
Revert "Normative: Remove class decorator access to private names"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -749,16 +749,14 @@ emu-example pre {
       <emu-alg>
         1. Let _finishers_ be a new empty List.
         1. For each _decorator_ in _decorators_, in reverse list order do
-          1. Let _privateElements_ be a List consisting of the ordered subsequence of _elements_ for each _element_ where _element_.[[Key]] is a Private Name.
-          1. Let _publicElements_ be a List consisting of the ordered subsequence of _elements_ for each _element_ where _element_.[[Key]] is not a Private Name.
-          1. Let _obj_ be FromClassDescriptor(_publicElements_).
+          1. Let _obj_ be FromClassDescriptor(_elements_).
           1. Let _result_ be ? Call(_decorator_, *undefined*, « _obj_ »).
           1. If _result_ is *undefined*, let _result_ be _obj_.
           1. Let _elementsAndFinisher_ be ? ToClassDescriptor(_result_).
           1. If _elementsAndFinisher_.[[Finisher]] is not *undefined*,
             1. Append _elementsAndFinisher_.[[Finisher]] to _finishers_.
           1. If _elementsAndFinisher_.[[Elements]] is not *undefined*,
-            1. Set _elements_ to the concatenation of _elementsAndFinisher_.[[Elements]] and _privateElements_.
+            1. Set _elements_ to _elementsAndFinisher_.[[Elements]].
             1. If there are two class elements _a_ and _b_ in _elements_ such that all of the following are true:
               1. _a_.[[Kind]] is not `"initializer"`
               1. _b_.[[Kind]] is not `"initializer"`


### PR DESCRIPTION
This reverts PR #151.

Rationale in https://github.com/tc39/proposal-decorators/issues/133#issuecomment-452676378