### PR TITLE
Normative: Splat out the property descriptor in the decorator descriptor

### DIFF
--- a/METAPROGRAMMING.md
+++ b/METAPROGRAMMING.md
@@ -85,7 +85,7 @@ For private fields or accessors, the `key` will be a Private Name--this is simil
 
 A class element descriptor with the following properties (optional properties are indicated with `?`):
 
-`{ kind, key, placement, descriptor, initializer, extras?, finisher? }`
+`{ kind, key, placement, ...descriptor, initializer, extras?, finisher? }`
 
 The optional additional properties:
 
@@ -111,7 +111,7 @@ A class element descriptor with the following properties:
 
 A class element descriptor with the following properties:
 
-`{ kind, key, placement, descriptor, extras?, finisher? }`
+`{ kind, key, placement, ...descriptor, extras?, finisher? }`
 
 ### Class Decorator
 
@@ -182,9 +182,8 @@ function defineElement(tagName) {
 
 // Create a bound version of the method as a field
 function bound(elementDescriptor) {
-  let { kind, key, descriptor } = elementDescriptor;
+  let { kind, key, value, enumerable, configurable, writable } = elementDescriptor;
   assert(kind == "method");
-  let { value } = descriptor
   function initializer() {
     return value.bind(this);
   }
@@ -194,7 +193,7 @@ function bound(elementDescriptor) {
   return {
     ...elementDescriptor,
     extras: [
-      { kind: "field", key, placement: "own", ...descriptor, value: undefined, initializer }
+      { kind: "field", key, placement: "own", enumerable, configurable, writable, value: undefined, initializer }
     ]
   }
 }
@@ -202,7 +201,7 @@ function bound(elementDescriptor) {
 // Whenever a read or write is done to a field, call the render()
 // method afterwards. Implement this by replacing the field with
 // a getter/setter pair.
-function observed({kind, key, placement, descriptor, initializer}) {
+function observed({kind, key, placement, enumerable, configurable, writable, initializer}) {
   assert(kind == "field");
   assert(placement == "own");
   // Create a new anonymous private name as a key for a class element
@@ -218,8 +217,8 @@ function observed({kind, key, placement, descriptor, initializer}) {
       // Assume the @bound decorator was used on render
       window.requestAnimationFrame(this.render);
     },
-    enumerable: descriptor.enumerable,
-    configurable: descriptor.configurable
+    enumerable,
+    configurable,
     extras: [underlying]
   };
 }

--- a/TABLE.md
+++ b/TABLE.md
@@ -7,14 +7,12 @@
 |`  key:`                    | -                                        |  *method name*                              |*property name*                                                   |*property name*                                      |
 |`  placement:`              | -                                        |`"prototype" \|\| "static"`                  |`"own" \|\| "static"`                                             |`"prototype" \|\| "static"`                          |
 |`  initializer:`            | -                                        | -                                           |*Function used to set the initial value of the field* <sup>2</sup>| -                                                   |
-|`  descriptor:{`            | -                                        |                                             |                                                                  |                                                     |
-|`    value:`                | -                                        |  *method function*                          | - <sup>3</sup>                                                   | -                                                   |
-|`    get:`                  | -                                        | -                                           | -                                                                |*getter function*                                    |
-|`    set:`                  | -                                        | -                                           | -                                                                |*setter function*                                    |
-|`    writable:`             | -                                        |`true`                                       |`true`                                                            | - <sup>5</sup>                                      |
-|`    configurable:`         | -                                        |`true`                                       |`true`                                                            |`true`                                               |
-|`    enumerable:`           | -                                        |`false`                                      |`false`                                                           |`false`                                              |
-|`  }`                       | -                                        |                                             |                                                                  |                                                     |
+|`  value:`                  | -                                        |  *method function*                          | - <sup>3</sup>                                                   | -                                                   |
+|`  get:`                    | -                                        | -                                           | -                                                                |*getter function*                                    |
+|`  set:`                    | -                                        | -                                           | -                                                                |*setter function*                                    |
+|`  writable:`               | -                                        |`true`                                       |`true`                                                            | - <sup>5</sup>                                      |
+|`  configurable:`           | -                                        |`true`                                       |`true`                                                            |`true`                                               |
+|`  enumerable:`             | -                                        |`false`                                      |`false`                                                           |`false`                                              |
 |`}`                         |                                          |                                             |                                                                  |                                                     |
 </table>
 
@@ -22,30 +20,28 @@
 
 <sup>2</sup> `initializer` function is present only if the field is initialized into the class body: `field = 10`. Please, check if exist before call it.
 
-<sup>3</sup> when `kind` is `field` don't include the value into the `descritor.value` and the value, if exist, is returned by `initializer` function.
+<sup>3</sup> when `kind` is `field`, don't include the value into the `value` and the value, if it exists, is returned by `initializer` function.
 
-<sup>4</sup> when the decorator is apply over a getter/setter `kind` is `method` and `descriptor.get` or `descriptor.set` has value. 
+<sup>4</sup> when the decorator is apply over a getter/setter `kind` is `method` and `get` or `set` has value. 
 
-<sup>5</sup> when `descriptor.get` or `descriptor.set` has value, the property descriptor don't include `writable` value.
+<sup>5</sup> when `get` or `set` has value, the property descriptor doesn't include `writable` value.
 
 | **return descriptor (optional)** | **`class`**                               | **`method()`**                           | **`field`**                                         | **`getter/setter`**                      | **Initializers**                         |
 |----------------------------------|-------------------------------------------|------------------------------------------|-----------------------------------------------------|------------------------------------------|------------------------------------------|
 |`{`                               |                                           |                                          |                                                     |                                          |                                          |
-|`  kind:`                         |`"class"`                                  |`"method"`                                |`"field"`                                            |`"method"`                                |`"initializer"` <sup>12</sup>             |
+|`  kind:`                         |`"class"`                                  |`"method"`                                |`"field"`                                            |`"method"`                                |`"initializer"` <sup>11</sup>             |
 |`  elements:`                     |*Array of member descriptors* <sup>6</sup> | -                                        | -                                                   | -                                        | -                                        |
 |`  key:`                          | -                                         |  *method name*    <sup>8</sup>           |*field name* <sup>8</sup>                            |*field name* <sup>8</sup>                 | -                                        |
 |`  placement:`                    | -                                         |`"prototype" \|\| "static" \|\| "own"`    |`"prototype" \|\| "static" \|\| "own"`               |`"prototype" \|\| "static" \|\| "own"`    |`"prototype" \|\| "static" \|\| "own"`    |
 |`  extras:`                       | -                                         |*Array of member descriptors* <sup>7</sup>|*Array of member descriptors* <sup>7</sup>           |*Array of member descriptors* <sup>7</sup>| -                                        |
-|`  initializer:`                  | -                                         |                                          |*Function used to set the initial value of the field*| - <sup>10</sup>                          | <sup>12</sup>                            |
-|`  descriptor:{`                  | -                                         | <sup>9</sup>                             | <sup>9</sup>                                        | <sup>9</sup>                             |                                          |
-|`    value:`                      | -                                         |*method function*                         | -                                                   | - <sup>10</sup>                          | -                                        |
-|`    get:`                        | -                                         | -                                        | -                                                   |*getter*                                  | -                                        |
-|`    set:`                        | -                                         | -                                        | -                                                   |*setter*                                  | -                                        |
-|`    writable:`                   | -                                         |`true \|\| false`                         |`true \|\| false`                                    | - <sup>10</sup>                          | -                                        |
-|`    configurable:`               | -                                         |`true \|\| false`                         |`true \|\| false`                                    |`true \|\| false`                         | -                                        |
-|`    enumerable:`                 | -                                         |`false \|\| true`                         |`false \|\| true`                                    |`false \|\| true`                         | -                                        |
-|`  }`                             | -                                         |                                          |                                                     |                                          |                                          |
-|`  finisher:`                     |*callback* <sup>11</sup>                   |  *callback* <sup>11</sup>                |  *callback* <sup>11</sup>                           |  *callback*    <sup>11</sup>             | -                                        |
+|`  initializer:`                  | -                                         |                                          |*Function used to set the initial value of the field*| - <sup>9</sup>                           | <sup>11</sup>                            |
+|`  value:`                        | -                                         |*method function*                         | -                                                   | - <sup>9</sup>                           | -                                        |
+|`  get:`                          | -                                         | -                                        | -                                                   |*getter*                                  | -                                        |
+|`  set:`                          | -                                         | -                                        | -                                                   |*setter*                                  | -                                        |
+|`  writable:`                     | -                                         |`true \|\| false`                         |`true \|\| false`                                    | - <sup>9</sup>                           | -                                        |
+|`  configurable:`                 | -                                         |`true \|\| false`                         |`true \|\| false`                                    |`true \|\| false`                         | -                                        |
+|`  enumerable:`                   | -                                         |`false \|\| true`                         |`false \|\| true`                                    |`false \|\| true`                         | -                                        |
+|`  finisher:`                     |*callback* <sup>10</sup>                   |  *callback* <sup>10</sup>                |  *callback* <sup>10</sup>                           |  *callback*    <sup>10</sup>             | -                                        |
 |`}`                               |                                           |                                          |                                                     |                                          |                                          |
 </tbody>    
 </table>
@@ -54,14 +50,12 @@
 
 <sup>7</sup> `extra` is an array of decorator descriptors, not to be confused with property descriptors. You can add other new members when a method or field is decorated.
 
-<sup>8</sup> `key` can be change from the original. If the member is private (`#name`) a `decorators.PrivateName(name)` is included in this property. It's a mandatory field.
+<sup>8</sup> `key` can be change from the original. If the member is private (`#name`) a PrivateName object is included in this property. It's a mandatory field.
 
-<sup>9</sup> `descriptor` is a mandatory field, but can be an empty object.
+<sup>9</sup> cannot include `initializer`, `value` or `writable` when `get` or `set` are defined.
 
-<sup>10</sup> cannot include `initializer`, `descriptor.value` or `descriptor.writable` when `descriptor.get` or `descriptor.set` are defined.
+<sup>10</sup> `finisher` function is a callback that is called at the end of class creation. It's optional.
 
-<sup>11</sup> `finisher` function is a callback that is called at the end of class creation. It's optional.
-
-<sup>12</sup> `kind: "initializer"` don't create new members. You can use the `initializer` field to include a callback to be used purely for perform a side effect. Do not confuse with the `initializer` property used to set the initial value to a field. 
+<sup>11</sup> `kind: "initializer"` don't create new members. You can use the `initializer` field to include a callback to be used purely for perform a side effect. Do not confuse with the `initializer` property used to set the initial value to a field. 
 
 **Note**: you can replace a field decorator with a method descriptor, or a getter, or vice-versa, but you can't interchange those with classes.

--- a/TAXONOMY.md
+++ b/TAXONOMY.md
@@ -27,12 +27,10 @@ Decorator reification (from the existing decorator proposal):
   kind: "method",
   key: "foo",
   placement: "static",
-  descriptor: {
-    value: function foo() {},
-    writable: true,
-    enumerable: false,
-    configurable: true
-  }
+  value: function foo() {},
+  writable: true,
+  enumerable: false,
+  configurable: true
 }
 ```
 
@@ -57,11 +55,9 @@ Decorator reification
   kind: "field",
   key: "foo",
   placement: "static",
-  descriptor: {
-    writable: true,
-    enumerable: true,
-    configurable: true
-  },
+  writable: true,
+  enumerable: true,
+  configurable: true
   initializer: () => bar
 }
 ```
@@ -88,12 +84,10 @@ Decorator reification (from the existing decorator proposal):
   kind: "method",
   key: "foo",
   placement: "static",
-  descriptor: {
-    get: function foo() {},
-    set: function foo(value) {},
-    enumerable: false,
-    configurable: true
-  }
+  get: function foo() {},
+  set: function foo(value) {},
+  enumerable: false,
+  configurable: true
 }
 ```
 
@@ -120,12 +114,10 @@ Decorator reification (from the existing decorator proposal):
   kind: "method",
   key: "foo",
   placement: "prototype",
-  descriptor: {
-    value: function foo() {},
-    writable: true,
-    enumerable: false,
-    configurable: true
-  }
+  value: function foo() {},
+  writable: true,
+  enumerable: false,
+  configurable: true
 }
 ```
 
@@ -150,11 +142,9 @@ Decorator reification
   kind: "field",
   key: "foo",
   placement: "own",
-  descriptor: {
-    writable: true,
-    enumerable: true,
-    configurable: true
-  },
+  writable: true,
+  enumerable: true,
+  configurable: true
   initializer: () => bar
 }
 ```
@@ -181,12 +171,10 @@ Decorator reification (from the existing decorator proposal):
   kind: "method",
   key: "foo",
   placement: "prototype",
-  descriptor: {
-    get: function foo() {},
-    set: function foo(value) {},
-    enumerable: false,
-    configurable: true
-  }
+  get: function foo() {},
+  set: function foo(value) {},
+  enumerable: false,
+  configurable: true
 }
 ```
 
@@ -217,12 +205,10 @@ Decorator reification:
   kind: "method",
   key: decorators.PrivateName("foo"),
   placement: "static",
-  descriptor: {
-    value: function foo() {},
-    writable: false,
-    enumerable: false,
-    configurable: false
-  }
+  value: function foo() {},
+  writable: false,
+  enumerable: false,
+  configurable: false
 }
 ```
 
@@ -245,11 +231,9 @@ Decorator reification
   kind: "field",
   key: decorators.PrivateName("foo"),
   placement: "static",
-  descriptor: {
-    writable: false,
-    enumerable: false,
-    configurable: false
-  },
+  writable: false,
+  enumerable: false,
+  configurable: false
   initializer: () => bar
 }
 ```
@@ -274,12 +258,10 @@ Decorator reification:
   kind: "method",
   key: decorators.PrivateName("foo"),
   placement: "static",
-  descriptor: {
-    get: function foo() {},
-    set: function foo(value) {},
-    enumerable: false,
-    configurable: false
-  }
+  get: function foo() {},
+  set: function foo(value) {},
+  enumerable: false,
+  configurable: false
 }
 ```
 
@@ -304,12 +286,10 @@ Decorator reification:
   kind: "method",
   key: decorators.PrivateName("foo"),
   placement: "own",
-  descriptor: {
-    value: function foo() {},
-    writable: true,
-    enumerable: false,
-    configurable: false
-  }
+  value: function foo() {},
+  writable: true,
+  enumerable: false,
+  configurable: false
 }
 ```
 
@@ -334,11 +314,9 @@ Decorator reification:
   kind: "field",
   key: decorators.PrivateName("foo"),
   placement: "own",
-  descriptor: {
-    writable: true,
-    enumerable: false,
-    configurable: false
-  },
+  writable: true,
+  enumerable: false,
+  configurable: false
   initializer: () => bar
 }
 ```
@@ -363,12 +341,10 @@ Decorator reification:
   kind: "method",
   key: decorators.PrivateName("foo"),
   placement: "own",
-  descriptor: {
-    get: function foo() {},
-    set: function foo(value) {},
-    enumerable: false,
-    configurable: false
-  }
+  get: function foo() {},
+  set: function foo(value) {},
+  enumerable: false,
+  configurable: false
 }
 ```
 

--- a/friend.js
+++ b/friend.js
@@ -81,12 +81,10 @@ export function inherit(descriptor) {
     kind: "method",
     key,
     placement,
-    descriptor: {
-      get() { return superKey.get(this); },
-      set(value) { set.set(this, value); },
-      configurable: false,
-      enumerable: false,
-    },
+    get() { return superKey.get(this); },
+    set(value) { set.set(this, value); },
+    configurable: false,
+    enumerable: false,
     finisher(klass) {
       superKey = exposeMap.get(klass, keyString);
       if (typeof superKey === undefined) {
@@ -211,25 +209,21 @@ export function abstract(descriptor) {
     key,
     kind: "method",
     placement: "own",
-    descriptor: {
-      get() {
-        return internalKey.get(this);
-      }
-      enumerable: false,
-      configurable: false,
+    get() {
+      return internalKey.get(this);
     }
-    finisher(klass) { abstractMap.set(klass, key.description, internalKey); }
+    enumerable: false,
+    configurable: false,
+    finisher(klass) { abstractMap.set(klass, key.description, internalKey); },
     extras: [
       {
         key: internalKey,
         kind: "method",
         placement: "own",
-        descriptor: {
-          value: isPure ? emptySentinel : value,
-          writable: true,
-          configurable: false,
-          enumerable: false,
-        }
+        value: isPure ? emptySentinel : value,
+        writable: true,
+        configurable: false,
+        enumerable: false,
       }
     ]
   }
@@ -252,14 +246,12 @@ export function override(descriptor) {
     kind: "method",
     key,
     placement,
-    descriptor: {
-      // All reads of the method read the underlying shared internal
-      // private name. This means that if the subclass is subclassed
-      // again, then it will still act as virtual.
-      get() { return get(internalKey, this); },
-      configurable: false,
-      enumerable: false,
-    },
+    // All reads of the method read the underlying shared internal
+    // private name. This means that if the subclass is subclassed
+    // again, then it will still act as virtual.
+    get() { return get(internalKey, this); },
+    configurable: false,
+    enumerable: false,
     finisher(klass) {
       internalKey = privateNameMap.get(klass, keyString);
       if (typeof internalKey === undefined) {
@@ -276,11 +268,9 @@ export function override(descriptor) {
         initializer() {
           set(internalKey, this, body);
         }
-        descriptor: {
-          writable: true,
-          configurable: false,
-          enumerable: false,
-        }
+        writable: true,
+        configurable: false,
+        enumerable: false,
       }
     ]
   };

--- a/spec.html
+++ b/spec.html
@@ -635,7 +635,7 @@ emu-example pre {
           kind: "method", "initializer", or "field"
           key: String, Symbol or Private Name,
           placement: "static", "prototype", or "own"
-          descriptor: PropertyDescriptor,
+          ...PropertyDescriptor,
           initializer?: Function
           extras?: ElementDescriptor[]
           finisher?: (klass): undefined or constructor;
@@ -817,7 +817,10 @@ emu-example pre {
       <h1>FromElementDescriptor ( _element_ )</h1>
       <emu-alg>
         1. Assert: _element_ is an ElementDescriptor Record.
-        1. Let _obj_ be ! ObjectCreate(%ObjectPrototype%).
+        1. If _element_.[[Kind]] is `"method"` or `"field"`,
+          1. Let _obj_ be ! FromPropertyDescriptor(_element_.[[Descriptor]])).
+        1. Otherwise,
+          1. Let _obj_ be ! ObjectCreate(%ObjectPrototype%).
         1. Let _desc_ be PropertyDescriptor{ [[Value]]: `"Descriptor"`, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
         1. Perform ! DefinePropertyOrThrow(_obj_, @@toStringTag, _desc_).
         1. Perform ! CreateDataPropertyOrThrow(_obj_, `"kind"`, _element_.[[Kind]]).
@@ -826,8 +829,6 @@ emu-example pre {
           1. If _key_ is a Private Name, set _key_ to ? PrivateNameObject(_key_).
           1. Perform ! CreateDataPropertyOrThrow(_obj_, `"key"`, _key_).
         1. Perform ! CreateDataPropertyOrThrow(_obj_, `"placement"`, _element_.[[Placement]]).
-        1. If _element_.[[Kind]] is `"method"` or `"field"`,
-          1. Perform ! CreateDataPropertyOrThrow(_obj_, `"descriptor"`, ! FromPropertyDescriptor(_element_.[[Descriptor]])).
         1. If _element_.[[Kind]] is `"field"` or `"initializer"`,
           1. Let _initializer_ be _element_.[[Initializer]].
           1. If _initializer_ is ~empty~, set _initializer_ to *undefined*.
@@ -871,11 +872,7 @@ emu-example pre {
         1. Otherwise, set _key_ to ? ToPropertyKey(_key_).
         1. Let _placement_ be ? ToString(? Get(_elementObject_, `"placement"`)).
         1. If _placement_ is not one of `"static"`, `"prototype"`, or `"own"`, throw a *TypeError* exception.
-        1. Let _descriptor_ be ? Get(_elementObject_, `"descriptor"`)
-        1. If _kind_ is `"initializer"`,
-          1. If _descriptor_ is not *undefined*, throw a *TypeError* exception.
-        1. Otherwise,
-          1. Set _descriptor_ to ? ToPropertyDescriptor(_descriptor_).
+        1. Let _descriptor_ be ? ToPropertyDescriptor(_elementObject_)
         1. If _key_ is a Private Name,
           1. If _descriptor_ has an [[Enumerable]] field and _descriptor_.[[Enumerable]] is *true*, throw a *TypeError* exception.
           1. If _descriptor_ has an [[Configurable]] field and _descriptor_.[[Configurable]] is *true*, throw a *TypeError* exception.
@@ -937,8 +934,8 @@ emu-example pre {
         1. If _key_ is not *undefined*, throw a *TypeError* exception.
         1. Let _placement_ be ? Get(_classDescriptor_, `"placement"`).
         1. If _placement_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _descriptor_ be ? Get(_classDescriptor_, `"descriptor"`).
-        1. If _descriptor_ is not *undefined*, throw a *TypeError* exception.
+        1. Let _descriptor_ be ? ToPropertyDescriptor(_classDescriptor_).
+        1. If _descriptor_ has any fields, throw a *TypeError* exception.
         1. Let _initializer_ be ? Get(_classDescriptor_, `"initializer"`).
         1. If _initializer_ is not *undefined*, throw a *TypeError* exception.
         1. Let _extras_ be ? Get(_classDescriptor_, `"extras"`).


### PR DESCRIPTION
This is an ergonomics improvement, as discussed in #173