### PR TITLE
DO NOT MERGE: Remove elements in favor of class extras

### DIFF
--- a/METAPROGRAMMING.md
+++ b/METAPROGRAMMING.md
@@ -121,7 +121,6 @@ A class descriptor with the following properties:
 ```js
 {
   kind: "class"
-  elements: Array of all class elements
 }
 ```
 
@@ -132,7 +131,7 @@ A class descriptor with the following properties:
 ```js
 {
   kind: "class"
-  elements: Possibly modified class elements (can include additional class elements)
+  extras: Additional class elements
 }
 ```
 
@@ -163,11 +162,10 @@ function defineElement(tagName) {
   // in the outer function and returns a different function that's called
   // when actually decorating the class (manual currying).
   return function(classDescriptor) {
-    let { kind, elements } = classDescriptor;
+    let { kind } = classDescriptor;
     assert(kind == "class");
     return {
       kind,
-      elements,
       // This callback is called once the class is otherwise fully defined
       extras: [
         {

--- a/TABLE.md
+++ b/TABLE.md
@@ -3,7 +3,6 @@
 |----------------------------|------------------------------------------|---------------------------------------------|------------------------------------------------------------------|-----------------------------------------------------|
 |`{`                         |                                          |                                             |                                                                  |                                                     |
 |`  kind:`                   |`"class"`                                 |`"method"`                                   |`"field"`                                                         |`"accessor"` <sup>4</sup>                            |
-|`  elements:`               |*Array of member descriptors* <sup>1</sup>| -                                           | -                                                                | -                                                   |
 |`  key:`                    | -                                        |  *method name*                              |*property name*                                                   |*property name*                                      |
 |`  placement:`              | -                                        |`"prototype" \|\| "static"`                  |`"own" \|\| "static"`                                             |`"prototype" \|\| "static"`                          |
 |`  initialize:`             | -                                        | -                                           |*Function used to set the initial value of the field* <sup>2</sup>| -                                                   |
@@ -15,8 +14,6 @@
 |`  enumerable:`             | -                                        |`false`                                      |`false`                                                           |`false`                                              |
 |`}`                         |                                          |                                             |                                                                  |                                                     |
 </table>
-
-<sup>1</sup> `element` is an array of decorator descriptors, not to be confused with property descriptors.
 
 <sup>2</sup> `initialize` function is present only if the field is initialized into the class body: `field = 10`. A declaration like `field;` has `initialize` as undefined. Please, check if exist before calling it.
 
@@ -30,7 +27,6 @@
 |----------------------------------|-------------------------------------------|------------------------------------------|-----------------------------------------------------|------------------------------------------|------------------------------------------|
 |`{`                               |                                           |                                          |                                                     |                                          |                                          |
 |`  kind:`                         |`"class"`                                  |`"method"`                                |`"field"`                                            |`"accessor"`                              |`"hook"` <sup>11</sup>                    |
-|`  elements:`                     |*Array of member descriptors* <sup>6</sup> | -                                        | -                                                   | -                                        | -                                        |
 |`  key:`                          | -                                         |  *method name*    <sup>8</sup>           |*field name* <sup>8</sup>                            |*field name* <sup>8</sup>                 | -                                        |
 |`  placement:`                    | -                                         |`"prototype" \|\| "static" \|\| "own"`    |`"prototype" \|\| "static" \|\| "own"`               |`"prototype" \|\| "static" \|\| "own"`    |`"prototype" \|\| "static" \|\| "own"`    |
 |`  extras:`                       | -                                         |*Array of member descriptors* <sup>7</sup>|*Array of member descriptors* <sup>7</sup>           |*Array of member descriptors* <sup>7</sup>| -                                        |

--- a/spec.html
+++ b/spec.html
@@ -739,7 +739,7 @@ emu-example pre {
         1. For each _element_ in _elements_, do
           1. Let _elements_ be ? DecorateElement(_element_, _placements_).
           1. Concatenate _elements_ onto _newElements_.
-        1. Return ? DecorateConstructor(_newElements_, _decorators_).
+        1. Return ? DecorateConstructor(_newElements_, _decorators_, _placements_).
       </emu-alg>
     </emu-clause>
 
@@ -769,7 +769,7 @@ emu-example pre {
       </emu-alg>
     </emu-clause>
     <emu-clause id=sec-decorate-constructor aoid=DecorateConstructor>
-      <h1>DecorateConstructor ( _elements_, _decorators_ )</h1>
+      <h1>DecorateConstructor ( _elements_, _decorators_, _placements_ )</h1>
       <p>With parameters _elements_, a List of Class Elements, and _decorators_, a List of decorator functions.</p>
       <emu-alg>
         1. For each _decorator_ in _decorators_, in reverse list order do
@@ -777,15 +777,10 @@ emu-example pre {
           1. Let _result_ be ? Call(_decorator_, *undefined*, « _obj_ »).
           1. If _result_ is *undefined*, let _result_ be _obj_.
           1. Otherwise, set _result_ to ? ToObject(_result_).
-          1. Let _newElements_ be ? ToClassDescriptor(_result_).
-          1. If _newElements_ is not *undefined*,
-            1. Set _elements_ to _newElements_.
-            1. If there are two class elements _a_ and _b_ in _elements_ such that all of the following are true:
-              1. _a_.[[Kind]] is not `"hook"`
-              1. _b_.[[Kind]] is not `"hook"`
-              1. _a_.[[Key]] is _b_.[[Key]]
-              1. _a_.[[Placement]] is _b_.[[Placement]]
-            1. Then, throw a *TypeError* exception.
+          1. Let _extras_ be ? ToClassDescriptor(_result_).
+          1. For each _element_ of _extras_,
+            1. ? AddElementPlacement(_element_, _placements_).
+          1. Concatenate _extras_ onto _elements_.
         1. Return the _elements_.
       </emu-alg>
     </emu-clause>
@@ -970,8 +965,6 @@ emu-example pre {
         1. If _kind_ is `"hook"`,
           1. If _start_, _replace_ and _finish_ are all *undefined*, throw a *TypeError* exception.
           1. If neither _replace_ nor _finish_ are *undefined*, throw a *TypeError* exception.
-        1. Let _elements_ be ? Get(_elementObject_, `"elements"`).
-        1. If _elements_ is not *undefined*, throw a *TypeError* exception.
         1. Let _element_ be the ElementDescriptor { [[Kind]]: _kind_, [[Placement]]: _placement_ }.
         1. If _kind_ is `"method"`, `"accessor"`, or `"field",
            1. Set _element_.[[Key]] to _key_.
@@ -1007,7 +1000,6 @@ emu-example pre {
         1. Let _desc_ be PropertyDescriptor{ [[Value]]: `"Descriptor"`, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.
         1. Perform ! DefinePropertyOrThrow(_obj_, @@toStringTag, _desc_).
         1. Perform ! CreateDataPropertyOrThrow(_obj_, `"kind"`, `"class"`).
-        1. Perform ! CreateDataPropertyOrThrow(_obj_, `"elements"`, _elementsObjects_).
         1. Return _obj_.
       </emu-alg>
     </emu-clause>
@@ -1027,10 +1019,7 @@ emu-example pre {
         1. If _initialize_ is not *undefined*, throw a *TypeError* exception.
         1. Let _start_ be ? Get(_classDescriptor_, `"start"`).
         1. If _start_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _extras_ be ? Get(_classDescriptor_, `"extras"`).
-        1. If _extras_ is not *undefined*, throw a *TypeError* exception.
-        1. Let _elementsObject_ be ? ToObject(? Get(_classDescriptor_, `"elements"`)).
-        1. Return ? ToElementDescriptors(_elementsObject_).
+        1. Return ? ToElementDescriptors(? ToObject(? Get(_classDescriptor_, `"extras"`))).
       </emu-alg>
     </emu-clause>
 


### PR DESCRIPTION
Initially, the decorators proposal had class descriptors which
contained an elements array with public and private elements.
Later, concerns were raised about exposing this private information
unexpectedly (#133), and this access was removed (#151).

However, this patch caused a problem: private field initializers
were accidentally sorted after public field initializers, an observable
and counterintuitive change (#183). Halfway solutions (#184) did
not really work out; we added back the full element support
in https://github.com/tc39/proposal-decorators/issues/133#issuecomment-452676378 .

Although we believe that it makes sense for decorators to be able
to see into class bodies, including private, and there are many
important use cases (for both public and private, #192), this support
doesn't have strict consensus in committee, so this patch serves
as a conservative option in case including elements is unacceptable.

This is not the preferred alternative, but it's a well-articulated
backup plan. I'm writing this out in advance in the interest of time,
to ensure that we have a path to Stage 3 and that this does not block
things.