### PR TITLE
Normative: Clarify that only constructor is non-decoratable

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -140,7 +140,7 @@ emu-example pre {
   <emu-clause id="sec-syntax-early-errors">
     <h1>Static Semantics: Early Errors</h1>
     <emu-grammar>
-        DecoratorList[?Yield, ?Await]? MethodDefinition[?Yield, ?Await]
+      ClassElement : DecoratorList? MethodDefinition
     </emu-grammar>
     <ul>
       <li>


### PR DESCRIPTION
The previous spec text for early errors for decorating a constructor
was not well-formed grammatically. The new grammar makes it clear
that we are only talking about non-static class elements.

Closes #212