### PR TITLE
Add note about TypeScript's implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,4 @@ To learn how to define your own decorators, see [METAPROGRAMMING.md](https://git
 
 ## Implementation status
 - [Babel](https://www.npmjs.com/package/@babel/plugin-proposal-decorators) -- included in 7.1+
+- [TypeScript](https://www.typescriptlang.org/docs/handbook/decorators.html) -- experimental flag in 3.3.3333


### PR DESCRIPTION
An experimental implementation was added to TypeScript in https://github.com/Microsoft/TypeScript/commit/62ba36908bceed22a52cee3269223189397cbab5.
One must enable the compiler flag `experimentalDecorators` to use it.