### PR TITLE
Editorial: Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ Statically analyzable decorators help tooling to generate faster and smaller Jav
 
 An attempt by LinkedIn to use the previous Stage 2 decorators proposal found that it led to a significant performance overhead. Members of the Polymer and TypeScript team also noticed a significant increase in generated code size with these decorators.
 
-By contrast, this decorator proposal should be compiled out into simply making function calls in particular places, or replacing one class element with another class element. We're working on proving out this benefit by implementing the proposal in Babel, so an informed comparison can be made before propsing for Stage 3.
+By contrast, this decorator proposal should be compiled out into simply making function calls in particular places, or replacing one class element with another class element. We're working on proving out this benefit by implementing the proposal in Babel, so an informed comparison can be made before proposing for Stage 3.
 
 Another case of static analyzability being useful for tooling was named exports from ES modules. The fixed nature of named imports and exports helps tree shaking, importing and exporting of types, and here, as the basis for the predictable nature of composed decorators. Even though the ecosystem remains in transition from exporting entirely dynamic objects, ES modules have taken root in tooling and found to be useful because, not despite, their more static nature.
 


### PR DESCRIPTION
Fixed a possible typo in README:
`propsing`-> `proposing`

In case the change is inaccurate, please let me know and I'll close this PR (^_^)