### PR TITLE
Minor fix to the `@logged` example definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ export decorator @logged {
       f.call(this, ...args);
       console.log(`ending ${name}`);
     }
-    wrapped.name = name;
+    Object.defineProperty(wrapped, "name", {
+      value: name,
+      configurable: true
+    });
     return wrapped;
   })
 }


### PR DESCRIPTION
Minor fix to the `@logged` example definition: the `name` property of functions is read-only so simply assigning to it won't work. But it's configurable, so you can set it with `defineProperty`. (https://tc39.es/ecma262/#sec-function-instances-name)