### PR TITLE
Fix PrivateKey example

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,10 @@ export class PrivateKey {
     return {get, set};
   }
   get(obj) {
-    return this.#get(obj);
+    return this.#get.call(obj);
   }
   set(obj, value) {
-    return this.#set(obj, value);
+    return this.#set.call(obj, value);
   }
 }
 ```


### PR DESCRIPTION
The `get`/`set` exposed to `PrivateKey` "are built to be `.call()`ed with the instance of the class as a receiver"