### PR TITLE
Fix name in context object for m method

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ class C {
   set #x(value) { return x_setter.call(this, value); }
 }
 
-C.prototype.m = logged(C.prototype.m, { kind: "method", name: "method", isStatic: false });
+C.prototype.m = logged(C.prototype.m, { kind: "method", name: "m", isStatic: false });
 x_setter = logged(x_setter, {kind: "setter", isStatic: false});
 ```
 


### PR DESCRIPTION
Looks like the kind text ("method") was accidentally used for the name field in the context object for this example.  "m" is the name of the method being decorated.