### PR TITLE
Cosmetic: close code block in EXTENSIONS.md

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -232,5 +232,6 @@ class C {
   #_() { return bar; }
   x = foo.call(this, this.#_);
 }
+```
 
 This pattern may improve certain "computed" reactivity patterns.


### PR DESCRIPTION
This closes a code block, resulting non-code text being properly outside the block.

Sorry to bother y'all with such a minor change!