### PR TITLE
Fix typo in "desugared" code sample on init-class

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ This example roughly "desugars" to the following (i.e., could be transpiled as s
 class C {}
 
 let { definition, initialize } = logged(C, {
-  kind: "class",
+  kind: "init-class",
   name: "C",
   defineMetadata() { /**/ }
 });


### PR DESCRIPTION
The code into which it should "desugar" seems like it should contain "init-class" in this situation.