### PR TITLE
Update README.md with current stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Decorators
 
+**Stage**: 2
+
 Decorators are a proposal for extending JavaScript classes which is widely adopted among developers in transpiler environments, with broad interest in standardization. TC39 has been iterating on decorators proposals for over five years. This document describes a new proposal for decorators based on elements from all past proposals.
 
 This README describes the current decorators proposal, which is a work in progress. For previous iterations of this proposal, see the commit history of this repository.


### PR DESCRIPTION
Adding current stage (as text) prominently at the top of the readme as seen [in](https://github.com/tc39/proposal-record-tuple) [many](https://github.com/tc39/proposal-upsert) [other](https://github.com/tc39/proposal-throw-expressions) [proposals](https://github.com/tc39/proposal-realms).  Confusion around stage was apparent with a [recent issue where the author thought it was stage 3](https://github.com/tc39/proposal-decorators/pull/387/files).