### PR TITLE
Update README adding missing super() in extends examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ function logged(value, { kind, name }) {
   if (kind === "class") {
     return class extends value {
       constructor(...args) {
+        super(...args);
         console.log(`constructing an instance of ${name} with arguments ${args.join(", ")}`);
       }
     }
@@ -559,6 +560,7 @@ function logged(value, { kind, name }) {
     return {
       definition: class extends value {
         constructor(...args) {
+          super(...args);
           console.log(`constructing an instance of ${name} with arguments ${args.join(", ")}`);
         }
       },


### PR DESCRIPTION
Adding `super()` calls to class decorator examples that extends a decorated class.