### PR TITLE
Remove field initializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The context object also varies depending on the value being decorated. Breaking 
 - `access`: An object containing methods to access the value. This is only available for _private_ class elements, since public class elements can be accessed externally by knowing the name of the element. These methods also get the _final_ value of the private element on the instance, not the current value passed to the decorator. This is important for most use cases involving access, such as type validators or serializers. See the section on Access below for more details.
 - `isStatic`: Whether or not the value is a `static` class element. Only applies to class elements.
 - `isPrivate`: Whether or not the value is a private class element. Only applies to class elements.
-- `addInitializer`: Allows the user to add additional initialization logic. This is available for all decorators which do not have kind `"field"` (discussed in more detail below).
+- `addInitializer`: Allows the user to add additional initialization logic. This is available for all decorators which operate per-class, as opposed to per-instance (in other words, decorators which do not have kind `"field"` - discussed in more detail below).
 - `setMetadata`: Allows the user to define some metadata to be associated with this property. This metadata can then be accessed on the class via `Symbol.metadata`. See the section on Metadata below for more details.
 
 See the Decorator APIs section below for a detailed breakdown of each type of decorator and how it is applied.


### PR DESCRIPTION
This PR builds on #436. As mentioned in that PR, one of the changes that was part of removing `@init:` was also removing the ability to add additional initializers for class fields.

Initializers added to class fields with `addInitializer` run immediately _after_ the field is defined. This design choice was primarily for consistency with the way that initializers for other member types worked at the time. It also ensured that there was no period _between_ decorator initializers and the class field's own initializer, which would result in users seeing a partially initialized field.

In order to keep these properties _and_ keep `addInitializer` for class fields, class instantiation would have to interleave checks for additional initializers between each class field assignment during class creation. This type of repeated, interleaving check was the reason that `@init:` was added in the first place, so avoiding it by removing class field initializers seems like a good idea.

In general, almost all use cases for class field initializers can be accomplished by using the field's own initializer, which the decorator has access to. The only cases which _cannot_ be accomplished this way are changes to the field's own property descriptor via redefining the field. So, we could not have an `@init:nonconfigurable` or `@init:nonenumerable` decorator. This seems like an acceptable tradeoff for a few reasons:

1. This type of redefinition would _immediately_ change the shape of the field that was just defined, and would result in two subsequent `defineProperty` calls (effectively), it is a suboptimal way of modifying these fundamental properties.
2. This capability for fields would _not_ be mirrored by method and accessor decorators. Initializers for methods and accessors run per instance, so they _cannot_ change the enumerability of methods (which are on the prototype). This introduces an awkward inconsistency.
3. Removing the capability from decorators also opens the door to a built-in syntax for changing these properties. This was discussed previously (years ago) but was punted on while decorators were hashed out. It can now be reopened.