### PR TITLE
Make desugared class method example match decorated example

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,7 @@ This example roughly "desugars" to the following (i.e., could be transpiled as s
 
 ```js
 class C {
-  m(arg) {
-    this.x = arg;
-  }
+  m(arg) {}
 }
 
 C.prototype.m = logged(C.prototype.m, {


### PR DESCRIPTION
The [example using decorators](https://github.com/tc39/proposal-decorators/blob/master/README.md?plain=1#L164) does not have any logic inside the method body. This confused me for a minute, but I assume the intent is that both methods do nothing, based on the subsequent examples.