### PR TITLE
Fix one remaining initialize -> init.

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ type ClassAutoAccessorDecorator = (
 ) => {
   get?: () => unknown;
   set?: (value: unknown) => void;
-  initialize?: (initialValue: unknown) => unknown;
+  init?: (initialValue: unknown) => unknown;
 } | void;
 ```
 


### PR DESCRIPTION
The rename was done ba3993d718b5632a8bad1abdb91036263458fc46 but the TypeScript definition hasn't been updated. This PR/commit fixes that.