### PR TITLE
fix: invalid syntax for ClassAutoAccessorDescriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ Auto-accessors can be decorated, and auto-accessor decorators have the following
 type ClassAutoAccessorDecorator = (
   value: {
     get: () => unknown;
-    set(value: unknown) => void;
+    set: (value: unknown) => void;
   },
   context: {
     kind: "accessor";


### PR DESCRIPTION
add a colon immediately following to the `value#set` property

prior to this change, this type would be considered invalid typescript syntax

> ':' expected.(1005)

TS Playground showing the errors surfaced by the type checker: https://www.typescriptlang.org/play?target=99#code/C4TwDgpgBAwgNgQwM5IIIFdgHtUGNcQpYBOAIhLiQtsVALxQAUAUFFAG4JzoQBcUAb1ZsoAcwjB+jAJT0AfFHQA7ANZKsAdyUBuYWyQTGnbn0Wr1W2XQXssASwAmutgF8ANMMpLgEAB6TBPSgVOyUHfgAiBHxCJBII5xElBABbUyRgYlDRKAAfKCQQFIAjLDhEtmiCFH4BMUNpfmU1TSU3AsNjHibzVsaOewcoFwqC4Go7XH5SsogEHSCwLM4faaxZ+dGEBwcASSU7YDsuOwAvCGJGUMPjuDOLqSsbQf7bR0SXZifAtnFgAH5HvIzC0tIkDACpF1TM0LEpvm8nMJrpCmCjbgA1LjdEFw76w1q6Fx5AbvIA