### PR TITLE
Meta: Fix an error in the logResult example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ Consider the following functions:
 ```js
 function logResult(fn) {
   return function(...args) {
+    let result;
     try {
-      const result = fn.call(this, ...args);
+      result = fn.call(this, ...args);
       console.log(result);
     } catch (e) {
-      console.error(result);
+      console.error(e);
       throw e;
     }
     return result;


### PR DESCRIPTION
**Summary**
This pull request makes a simple fix to the example `logResult` code.

**Changes**
* Lifted result variable outside the try block scope
* Updated the catch block to log the error **

----

** Alternatively to logging the error, it could log the result variable, which would be the value of undefined. Happy to do that, just let me know.