### PR TITLE
Clarify specification for “context.name” for private vs public elements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The context object also varies depending on the value being decorated. Breaking 
   - `"setter"`
   - `"field"`
   - `"accessor"`
-- `name`: The name of the value, or in the case of private elements the _description_ of it (e.g. the readable name).
+- `name`: The string name of the value, or in the case of `private` elements a unique symbol with a _description_ of the value (e.g. `'field'` or `Symbol('#field')`).
 - `access`: An object containing methods to access the value. These methods also get the _final_ value of the element on the instance, not the current value passed to the decorator. This is important for most use cases involving access, such as type validators or serializers. See the section on Access below for more details.
 - `static`: Whether or not the value is a `static` class element. Only applies to class elements.
 - `private`: Whether or not the value is a private class element. Only applies to class elements.


### PR DESCRIPTION
The babel transpiler I’m using appears to always return a _string_ here (even for private elements). When I looked back at this proposal, it felt like there was potentially room for interpretation!

This attempts to make two things more explicit:
1. If the element is private, `context.name` returns a `Symbol`, not a `String`.
2. And, if the element is private `context.name.description` is a `#`-prefixed string mirroring the name provided by the developer.

```js
class Example {
  @decorator
  accessor #field;  // Expected: context.name = Symbol('#field')
                    // ✗ Babel:  context.name = '#field'

  @decorator
  accessor field;   // Expected: context.name = 'field'
                    // ✔ Babel:  context.name = 'field'
}
```